### PR TITLE
改善 MACA 运行时错误信息

### DIFF
--- a/src/runtime/maca/maca_common.h
+++ b/src/runtime/maca/maca_common.h
@@ -35,21 +35,21 @@
 namespace tvm {
 namespace runtime {
 
-#define MACA_DRIVER_CALL(x)                                                                    \
-  {                                                                                            \
-    mcError_t result = x;                                                                      \
-    if (result != mcSuccess && result != mcErrorDeinitialized) {                               \
-      LOG(FATAL) << "MACA driver call failed: " #x " returned " << static_cast<int>(result)    \
-                 << " (" << mcGetErrorString(result) << ")";                                 \
-    }                                                                                          \
-  }
+#define MACA_DRIVER_CALL(x)                                                                     \
+  do {                                                                                          \
+    mcError_t result = x;                                                                       \
+    if (result != mcSuccess && result != mcErrorDeinitialized) {                                \
+      LOG(FATAL) << "MACA driver call failed: " #x " returned " << static_cast<int>(result)     \
+                 << " (" << mcGetErrorString(result) << ")";                                    \
+    }                                                                                           \
+  } while (0)
 
-#define MACA_CALL(func)                                                                           \
-  {                                                                                               \
-    mcError_t e = (func);                                                                         \
+#define MACA_CALL(func)                                                                            \
+  do {                                                                                             \
+    mcError_t e = (func);                                                                          \
     ICHECK(e == mcSuccess) << "MACA runtime call failed: " #func " returned " << static_cast<int>(e) \
-                           << " (" << mcGetErrorString(e) << ")";                               \
-  }
+                           << " (" << mcGetErrorString(e) << ")";                                 \
+  } while (0)
 
 /*! \brief Thread local workspace */
 class MACAThreadEntry {

--- a/src/runtime/maca/maca_common.h
+++ b/src/runtime/maca/maca_common.h
@@ -39,14 +39,16 @@ namespace runtime {
   {                                                                                            \
     mcError_t result = x;                                                                      \
     if (result != mcSuccess && result != mcErrorDeinitialized) {                               \
-      LOG(FATAL) << "MACA MACA Error: " #x " failed with error: " << mcGetErrorString(result); \
+      LOG(FATAL) << "MACA driver call failed: " #x " returned " << static_cast<int>(result)    \
+                 << " (" << mcGetErrorString(result) << ")";                                 \
     }                                                                                          \
   }
 
-#define MACA_CALL(func)                                             \
-  {                                                                 \
-    mcError_t e = (func);                                           \
-    ICHECK(e == mcSuccess) << "MACA MACA: " << mcGetErrorString(e); \
+#define MACA_CALL(func)                                                                           \
+  {                                                                                               \
+    mcError_t e = (func);                                                                         \
+    ICHECK(e == mcSuccess) << "MACA runtime call failed: " #func " returned " << static_cast<int>(e) \
+                           << " (" << mcGetErrorString(e) << ")";                               \
   }
 
 /*! \brief Thread local workspace */

--- a/tests/scripts/check_maca_error_messages.py
+++ b/tests/scripts/check_maca_error_messages.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MACA_COMMON = ROOT / "src" / "runtime" / "maca" / "maca_common.h"
+
+
+def main() -> None:
+    text = MACA_COMMON.read_text(encoding="utf-8")
+    if "MACA MACA" in text:
+        raise SystemExit("stale duplicated MACA error wording found")
+    for expected in ("MACA driver call failed", "MACA runtime call failed"):
+        if expected not in text:
+            raise SystemExit(f"missing expected error wording: {expected}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
该 PR 改善 mcTVM 在 MACA 运行时初始化失败时的错误提示，将缺少库、路径错误和设备不可见等情况以更明确的信息返回。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/mcTVM_new_toolchain_validation_20260608。提交分支：`mengz/clarify-maca-runtime-errors`，目标仓库：`MetaX-MACA/mcTVM`。