### PR TITLE
支持配置 MACA kernel 输出目录

### DIFF
--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -31,6 +31,12 @@ from ..base import py_str
 from . import utils
 
 
+def _get_kernels_output_dir(pass_context):
+    if "maca.kernels_output_dir" in pass_context.config:
+        return pass_context.config["maca.kernels_output_dir"]
+    return os.environ.get("TVM_MACA_KERNELS_OUTPUT_DIR")
+
+
 def compile_maca(
     code, target_format="mcbin", arch=None, options=None, path_target=None
 ):  # pylint: disable=unused-argument
@@ -66,11 +72,7 @@ def compile_maca(
     temp_target = temp.relpath(f"{file_name}.{target_format}")
 
     pass_context = tvm_ffi.get_global_func("transform.GetCurrentPassContext")()
-    kernels_output_dir = (
-        pass_context.config["maca.kernels_output_dir"]
-        if "maca.kernels_output_dir" in pass_context.config
-        else None
-    )
+    kernels_output_dir = _get_kernels_output_dir(pass_context)
     if kernels_output_dir is not None:
         if not os.path.isdir(kernels_output_dir):
             os.makedirs(kernels_output_dir)

--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -32,7 +32,7 @@ from . import utils
 
 
 def _get_kernels_output_dir(pass_context):
-    if "maca.kernels_output_dir" in pass_context.config:
+    if pass_context is not None and "maca.kernels_output_dir" in pass_context.config:
         return pass_context.config["maca.kernels_output_dir"]
     return os.environ.get("TVM_MACA_KERNELS_OUTPUT_DIR")
 

--- a/tests/python/contrib/test_mxcc_kernel_output_dir.py
+++ b/tests/python/contrib/test_mxcc_kernel_output_dir.py
@@ -1,45 +1,28 @@
-import ast
 import os
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-
-def _load_output_dir_helper():
-    source_path = (
-        Path(__file__).resolve().parents[3] / "python" / "tvm" / "contrib" / "mxcc.py"
-    )
-    tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    nodes = [
-        node
-        for node in tree.body
-        if (
-            isinstance(node, ast.Import)
-            and all(alias.name == "os" for alias in node.names)
-        )
-        or (isinstance(node, ast.FunctionDef) and node.name == "_get_kernels_output_dir")
-    ]
-    module = ast.Module(body=nodes, type_ignores=[])
-    ast.fix_missing_locations(module)
-    namespace = {}
-    exec(compile(module, str(source_path), "exec"), namespace)
-    return namespace["_get_kernels_output_dir"]
+from tvm.contrib.mxcc import _get_kernels_output_dir
 
 
 def test_kernel_output_dir_uses_pass_context_first():
-    get_output_dir = _load_output_dir_helper()
     pass_context = SimpleNamespace(config={"maca.kernels_output_dir": "/ctx"})
     with patch.dict(os.environ, {"TVM_MACA_KERNELS_OUTPUT_DIR": "/env"}, clear=True):
-        assert get_output_dir(pass_context) == "/ctx"
+        assert _get_kernels_output_dir(pass_context) == "/ctx"
 
 
 def test_kernel_output_dir_falls_back_to_env():
-    get_output_dir = _load_output_dir_helper()
     pass_context = SimpleNamespace(config={})
     with patch.dict(os.environ, {"TVM_MACA_KERNELS_OUTPUT_DIR": "/env"}, clear=True):
-        assert get_output_dir(pass_context) == "/env"
+        assert _get_kernels_output_dir(pass_context) == "/env"
+
+
+def test_kernel_output_dir_accepts_missing_pass_context():
+    with patch.dict(os.environ, {"TVM_MACA_KERNELS_OUTPUT_DIR": "/env"}, clear=True):
+        assert _get_kernels_output_dir(None) == "/env"
 
 
 if __name__ == "__main__":
     test_kernel_output_dir_uses_pass_context_first()
     test_kernel_output_dir_falls_back_to_env()
+    test_kernel_output_dir_accepts_missing_pass_context()

--- a/tests/python/contrib/test_mxcc_kernel_output_dir.py
+++ b/tests/python/contrib/test_mxcc_kernel_output_dir.py
@@ -1,0 +1,45 @@
+import ast
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _load_output_dir_helper():
+    source_path = (
+        Path(__file__).resolve().parents[3] / "python" / "tvm" / "contrib" / "mxcc.py"
+    )
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    nodes = [
+        node
+        for node in tree.body
+        if (
+            isinstance(node, ast.Import)
+            and all(alias.name == "os" for alias in node.names)
+        )
+        or (isinstance(node, ast.FunctionDef) and node.name == "_get_kernels_output_dir")
+    ]
+    module = ast.Module(body=nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(source_path), "exec"), namespace)
+    return namespace["_get_kernels_output_dir"]
+
+
+def test_kernel_output_dir_uses_pass_context_first():
+    get_output_dir = _load_output_dir_helper()
+    pass_context = SimpleNamespace(config={"maca.kernels_output_dir": "/ctx"})
+    with patch.dict(os.environ, {"TVM_MACA_KERNELS_OUTPUT_DIR": "/env"}, clear=True):
+        assert get_output_dir(pass_context) == "/ctx"
+
+
+def test_kernel_output_dir_falls_back_to_env():
+    get_output_dir = _load_output_dir_helper()
+    pass_context = SimpleNamespace(config={})
+    with patch.dict(os.environ, {"TVM_MACA_KERNELS_OUTPUT_DIR": "/env"}, clear=True):
+        assert get_output_dir(pass_context) == "/env"
+
+
+if __name__ == "__main__":
+    test_kernel_output_dir_uses_pass_context_first()
+    test_kernel_output_dir_falls_back_to_env()


### PR DESCRIPTION
该 PR 增加通过环境变量配置 MACA kernel 输出目录的能力，方便在容器和 CI 中隔离编译产物并归档调试文件。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/mcTVM_new_toolchain_validation_20260608。提交分支：`mengz/env-maca-kernel-output-dir`，目标仓库：`MetaX-MACA/mcTVM`。