### PR TITLE
增加 mxcc 编译超时控制

### DIFF
--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -121,7 +121,10 @@ def compile_maca(
     try:
         (out, _) = proc.communicate(timeout=_get_mxcc_timeout())
     except subprocess.TimeoutExpired as err:
-        proc.kill()
+        try:
+            proc.kill()
+        except OSError:
+            pass
         out, _ = proc.communicate()
         msg = "MACA compilation timed out"
         msg += f" after {err.timeout} seconds:\n"

--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -31,6 +31,19 @@ from ..base import py_str
 from . import utils
 
 
+def _get_mxcc_timeout():
+    value = os.environ.get("TVM_MXCC_TIMEOUT")
+    if not value:
+        return None
+    try:
+        timeout = float(value)
+    except ValueError as err:
+        raise ValueError("TVM_MXCC_TIMEOUT must be a positive number") from err
+    if timeout <= 0:
+        raise ValueError("TVM_MXCC_TIMEOUT must be a positive number")
+    return timeout
+
+
 def compile_maca(
     code, target_format="mcbin", arch=None, options=None, path_target=None
 ):  # pylint: disable=unused-argument
@@ -105,7 +118,17 @@ def compile_maca(
 
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-    (out, _) = proc.communicate()
+    try:
+        (out, _) = proc.communicate(timeout=_get_mxcc_timeout())
+    except subprocess.TimeoutExpired as err:
+        proc.kill()
+        out, _ = proc.communicate()
+        msg = "MACA compilation timed out"
+        msg += f" after {err.timeout} seconds:\n"
+        msg += " ".join(cmd)
+        msg += "\nCompiler output before timeout:\n"
+        msg += py_str(out)
+        raise RuntimeError(msg) from err
 
     if proc.returncode != 0:
         msg = code

--- a/tests/python/contrib/test_mxcc_timeout.py
+++ b/tests/python/contrib/test_mxcc_timeout.py
@@ -1,45 +1,20 @@
-import ast
 import os
-from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 
-def _load_timeout_helper():
-    source_path = (
-        Path(__file__).resolve().parents[3] / "python" / "tvm" / "contrib" / "mxcc.py"
-    )
-    tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    nodes = [
-        node
-        for node in tree.body
-        if (
-            isinstance(node, ast.Import)
-            and all(alias.name == "os" for alias in node.names)
-        )
-        or (isinstance(node, ast.FunctionDef) and node.name == "_get_mxcc_timeout")
-    ]
-    module = ast.Module(body=nodes, type_ignores=[])
-    ast.fix_missing_locations(module)
-    namespace = {}
-    exec(compile(module, str(source_path), "exec"), namespace)
-    return namespace["_get_mxcc_timeout"]
+from tvm.contrib.mxcc import _get_mxcc_timeout
 
 
 def test_mxcc_timeout_accepts_positive_float():
-    get_timeout = _load_timeout_helper()
     with patch.dict(os.environ, {"TVM_MXCC_TIMEOUT": "12.5"}, clear=True):
-        assert get_timeout() == 12.5
+        assert _get_mxcc_timeout() == 12.5
 
 
 def test_mxcc_timeout_rejects_invalid_value():
-    get_timeout = _load_timeout_helper()
     with patch.dict(os.environ, {"TVM_MXCC_TIMEOUT": "0"}, clear=True):
-        try:
-            get_timeout()
-        except ValueError as err:
-            assert "positive number" in str(err)
-        else:
-            raise AssertionError("expected ValueError")
+        with pytest.raises(ValueError, match="positive number"):
+            _get_mxcc_timeout()
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_mxcc_timeout.py
+++ b/tests/python/contrib/test_mxcc_timeout.py
@@ -1,0 +1,47 @@
+import ast
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_timeout_helper():
+    source_path = (
+        Path(__file__).resolve().parents[3] / "python" / "tvm" / "contrib" / "mxcc.py"
+    )
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    nodes = [
+        node
+        for node in tree.body
+        if (
+            isinstance(node, ast.Import)
+            and all(alias.name == "os" for alias in node.names)
+        )
+        or (isinstance(node, ast.FunctionDef) and node.name == "_get_mxcc_timeout")
+    ]
+    module = ast.Module(body=nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(source_path), "exec"), namespace)
+    return namespace["_get_mxcc_timeout"]
+
+
+def test_mxcc_timeout_accepts_positive_float():
+    get_timeout = _load_timeout_helper()
+    with patch.dict(os.environ, {"TVM_MXCC_TIMEOUT": "12.5"}, clear=True):
+        assert get_timeout() == 12.5
+
+
+def test_mxcc_timeout_rejects_invalid_value():
+    get_timeout = _load_timeout_helper()
+    with patch.dict(os.environ, {"TVM_MXCC_TIMEOUT": "0"}, clear=True):
+        try:
+            get_timeout()
+        except ValueError as err:
+            assert "positive number" in str(err)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+if __name__ == "__main__":
+    test_mxcc_timeout_accepts_positive_float()
+    test_mxcc_timeout_rejects_invalid_value()


### PR DESCRIPTION
该 PR 为 mxcc 编译流程增加超时控制，避免异常工具链或错误参数导致测试任务长期卡住。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/mcTVM_new_toolchain_validation_20260608。提交分支：`mengz/mxcc-compile-timeout`，目标仓库：`MetaX-MACA/mcTVM`。