### PR TITLE
支持环境变量注入 mxcc 额外参数

### DIFF
--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import as _abs
 
 import re
 import os
+import shlex
 import subprocess
 import warnings
 from typing import Tuple
@@ -29,6 +30,13 @@ from tvm.target import Target
 
 from ..base import py_str
 from . import utils
+
+
+def _get_env_mxcc_options():
+    value = os.environ.get("TVM_MXCC_OPTIONS")
+    if not value:
+        return []
+    return shlex.split(value)
 
 
 def compile_maca(
@@ -99,6 +107,7 @@ def compile_maca(
             cmd += options
         else:
             raise ValueError("options must be str of list of str")
+    cmd += _get_env_mxcc_options()
 
     cmd += ["-D__FAST_HALF_CVT__", "-o", file_target]
     cmd += [temp_code]

--- a/tests/python/contrib/test_mxcc_env_options.py
+++ b/tests/python/contrib/test_mxcc_env_options.py
@@ -1,0 +1,42 @@
+import ast
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_env_options_helper():
+    source_path = (
+        Path(__file__).resolve().parents[3] / "python" / "tvm" / "contrib" / "mxcc.py"
+    )
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    nodes = [
+        node
+        for node in tree.body
+        if (
+            isinstance(node, ast.Import)
+            and all(alias.name in {"os", "shlex"} for alias in node.names)
+        )
+        or (isinstance(node, ast.FunctionDef) and node.name == "_get_env_mxcc_options")
+    ]
+    module = ast.Module(body=nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(source_path), "exec"), namespace)
+    return namespace["_get_env_mxcc_options"]
+
+
+def test_env_mxcc_options_are_shell_split():
+    get_options = _load_env_options_helper()
+    with patch.dict(os.environ, {"TVM_MXCC_OPTIONS": "--flag 'two words'"}, clear=True):
+        assert get_options() == ["--flag", "two words"]
+
+
+def test_env_mxcc_options_default_empty():
+    get_options = _load_env_options_helper()
+    with patch.dict(os.environ, {}, clear=True):
+        assert get_options() == []
+
+
+if __name__ == "__main__":
+    test_env_mxcc_options_are_shell_split()
+    test_env_mxcc_options_default_empty()

--- a/tests/python/contrib/test_mxcc_env_options.py
+++ b/tests/python/contrib/test_mxcc_env_options.py
@@ -1,40 +1,16 @@
-import ast
 import os
-from pathlib import Path
 from unittest.mock import patch
-
-
-def _load_env_options_helper():
-    source_path = (
-        Path(__file__).resolve().parents[3] / "python" / "tvm" / "contrib" / "mxcc.py"
-    )
-    tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    nodes = [
-        node
-        for node in tree.body
-        if (
-            isinstance(node, ast.Import)
-            and all(alias.name in {"os", "shlex"} for alias in node.names)
-        )
-        or (isinstance(node, ast.FunctionDef) and node.name == "_get_env_mxcc_options")
-    ]
-    module = ast.Module(body=nodes, type_ignores=[])
-    ast.fix_missing_locations(module)
-    namespace = {}
-    exec(compile(module, str(source_path), "exec"), namespace)
-    return namespace["_get_env_mxcc_options"]
+from tvm.contrib.mxcc import _get_env_mxcc_options
 
 
 def test_env_mxcc_options_are_shell_split():
-    get_options = _load_env_options_helper()
     with patch.dict(os.environ, {"TVM_MXCC_OPTIONS": "--flag 'two words'"}, clear=True):
-        assert get_options() == ["--flag", "two words"]
+        assert _get_env_mxcc_options() == ["--flag", "two words"]
 
 
 def test_env_mxcc_options_default_empty():
-    get_options = _load_env_options_helper()
     with patch.dict(os.environ, {}, clear=True):
-        assert get_options() == []
+        assert _get_env_mxcc_options() == []
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
该 PR 支持通过环境变量为 mxcc 注入额外编译选项，便于在不修改源码的情况下测试不同架构、调试或优化参数。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/mcTVM_new_toolchain_validation_20260608。提交分支：`mengz/mxcc-extra-options-env`，目标仓库：`MetaX-MACA/mcTVM`。