### PR TITLE
规范化 MACA 架构版本

### DIFF
--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -145,6 +145,30 @@ def parse_compute_version(compute_version):
         raise RuntimeError("Compute version parsing error: " + str(err))
 
 
+def normalize_maca_arch(arch):
+    """Normalize MACA arch strings to compute version strings.
+
+    Examples
+    --------
+    xcore1000 -> 10.0
+    xcore1030 -> 10.30
+    10.0 -> 10.0
+    """
+    arch = arch.lower()
+    if arch.startswith("xcore"):
+        arch = arch[len("xcore") :]
+    if "." in arch:
+        parse_compute_version(arch)
+        return arch
+    if not arch.isdigit() or len(arch) < 3:
+        raise RuntimeError("MACA architecture parsing error: " + arch)
+    major = arch[:2]
+    minor = arch[2:]
+    if set(minor) == {"0"}:
+        minor = "0"
+    return major + "." + minor
+
+
 @tvm_ffi.register_global_func("tvm_callback_maca_have_wmma")
 def have_wmma(compute_version=None):
     """Either wmma support is provided in the compute capability or not
@@ -274,12 +298,7 @@ def get_target_compute_version(target=None):
     # 2. Target.current()
     target = target or tvm.target.Target.current()
     if target and target.mcpu:
-        arch = target.mcpu[5:]
-        major = arch[:2]
-        minor = arch[2:]
-        if minor == "00":
-            minor = "0"
-        return major + "." + minor
+        return normalize_maca_arch(target.mcpu)
 
     # 3. GPU compute version
     if tvm.maca(0).exist:

--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -237,7 +237,7 @@ def get_maca_arch(maca_path="/opt/maca"):
         # Use regex to match the "Name" field
         match = re.search(r"Name:\s+(XCORE\d+[a-zA-Z]*)", macainfo_output)
         if match:
-            gpu_arch = match.group(1)
+            gpu_arch = re.sub(r"^(xcore\d+)[a-z]+$", r"\1", match.group(1).lower())
         return gpu_arch.lower()
     except subprocess.CalledProcessError:
         print(

--- a/tests/python/contrib/test_mxcc_arch_normalize.py
+++ b/tests/python/contrib/test_mxcc_arch_normalize.py
@@ -1,41 +1,29 @@
-import ast
-from pathlib import Path
+from unittest.mock import patch
 
+import pytest
 
-def _load_arch_helpers():
-    source_path = (
-        Path(__file__).resolve().parents[3] / "python" / "tvm" / "contrib" / "mxcc.py"
-    )
-    tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    wanted = {"parse_compute_version", "normalize_maca_arch"}
-    nodes = [
-        node
-        for node in tree.body
-        if isinstance(node, ast.FunctionDef) and node.name in wanted
-    ]
-    module = ast.Module(body=nodes, type_ignores=[])
-    ast.fix_missing_locations(module)
-    namespace = {}
-    exec(compile(module, str(source_path), "exec"), namespace)
-    return namespace
+from tvm.contrib.mxcc import get_maca_arch, normalize_maca_arch
 
 
 def test_normalize_maca_arch_accepts_xcore_and_compute_version():
-    helpers = _load_arch_helpers()
-
-    assert helpers["normalize_maca_arch"]("xcore1000") == "10.0"
-    assert helpers["normalize_maca_arch"]("xcore1030") == "10.30"
-    assert helpers["normalize_maca_arch"]("10.0") == "10.0"
+    assert normalize_maca_arch("xcore1000") == "10.0"
+    assert normalize_maca_arch("xcore1000b") == "10.0"
+    assert normalize_maca_arch("xcore1030") == "10.30"
+    assert normalize_maca_arch("10.0") == "10.0"
 
 
 def test_normalize_maca_arch_rejects_unknown_string():
-    helpers = _load_arch_helpers()
-    try:
-        helpers["normalize_maca_arch"]("xcore")
-    except RuntimeError as err:
-        assert "architecture parsing" in str(err)
-    else:
-        raise AssertionError("expected RuntimeError")
+    with pytest.raises(RuntimeError, match="architecture parsing"):
+        normalize_maca_arch("xcore")
+
+
+def test_get_maca_arch_strips_vendor_suffix():
+    with patch("tvm.contrib.mxcc.os.path.exists", return_value=True):
+        with patch(
+            "tvm.contrib.mxcc.subprocess.check_output",
+            return_value=b"Name: XCORE1000B\n",
+        ):
+            assert get_maca_arch("/opt/maca") == "xcore1000"
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_mxcc_arch_normalize.py
+++ b/tests/python/contrib/test_mxcc_arch_normalize.py
@@ -1,0 +1,43 @@
+import ast
+from pathlib import Path
+
+
+def _load_arch_helpers():
+    source_path = (
+        Path(__file__).resolve().parents[3] / "python" / "tvm" / "contrib" / "mxcc.py"
+    )
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    wanted = {"parse_compute_version", "normalize_maca_arch"}
+    nodes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in wanted
+    ]
+    module = ast.Module(body=nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(source_path), "exec"), namespace)
+    return namespace
+
+
+def test_normalize_maca_arch_accepts_xcore_and_compute_version():
+    helpers = _load_arch_helpers()
+
+    assert helpers["normalize_maca_arch"]("xcore1000") == "10.0"
+    assert helpers["normalize_maca_arch"]("xcore1030") == "10.30"
+    assert helpers["normalize_maca_arch"]("10.0") == "10.0"
+
+
+def test_normalize_maca_arch_rejects_unknown_string():
+    helpers = _load_arch_helpers()
+    try:
+        helpers["normalize_maca_arch"]("xcore")
+    except RuntimeError as err:
+        assert "architecture parsing" in str(err)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+if __name__ == "__main__":
+    test_normalize_maca_arch_accepts_xcore_and_compute_version()
+    test_normalize_maca_arch_rejects_unknown_string()


### PR DESCRIPTION
该 PR 对 MACA 架构版本字符串做规范化处理，减少大小写、前缀和格式差异对编译参数生成的影响。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/mcTVM_new_toolchain_validation_20260608。提交分支：`mengz/normalize-maca-arch-version`，目标仓库：`MetaX-MACA/mcTVM`。