### PR TITLE
编译失败时报告 mxcc 命令

### DIFF
--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import as _abs
 
 import re
 import os
+import shlex
 import subprocess
 import warnings
 from typing import Tuple
@@ -29,6 +30,21 @@ from tvm.target import Target
 
 from ..base import py_str
 from . import utils
+
+
+def _format_mxcc_error(cmd, compiler_output, code):
+    """Format an mxcc failure with enough context for reproduction."""
+    return "\n".join(
+        [
+            "MACA compilation failed.",
+            "Command:",
+            shlex.join(cmd),
+            "Compiler output:",
+            py_str(compiler_output),
+            "Source:",
+            code,
+        ]
+    )
 
 
 def compile_maca(
@@ -108,10 +124,7 @@ def compile_maca(
     (out, _) = proc.communicate()
 
     if proc.returncode != 0:
-        msg = code
-        msg += "\nCompilation error:\n"
-        msg += py_str(out)
-        raise RuntimeError(msg)
+        raise RuntimeError(_format_mxcc_error(cmd, out, code))
 
     with open(file_target, "rb") as f:
         data = bytearray(f.read())

--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -34,13 +34,18 @@ from . import utils
 
 def _format_mxcc_error(cmd, compiler_output, code):
     """Format an mxcc failure with enough context for reproduction."""
+    command_text = shlex.join([str(part) for part in cmd])
+    if isinstance(compiler_output, bytes):
+        compiler_text = compiler_output.decode("utf-8", errors="replace")
+    else:
+        compiler_text = py_str(compiler_output)
     return "\n".join(
         [
             "MACA compilation failed.",
             "Command:",
-            shlex.join(cmd),
+            command_text,
             "Compiler output:",
-            py_str(compiler_output),
+            compiler_text,
             "Source:",
             code,
         ]

--- a/tests/python/contrib/test_mxcc_error_message.py
+++ b/tests/python/contrib/test_mxcc_error_message.py
@@ -1,59 +1,21 @@
-import importlib.util
-import sys
-import types
-import unittest
 from pathlib import Path
 
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-MXCC_PATH = REPO_ROOT / "python" / "tvm" / "contrib" / "mxcc.py"
-
-tvm_ffi = types.ModuleType("tvm_ffi")
-tvm_ffi.register_global_func = lambda *args, **kwargs: (
-    (lambda func: func) if args and callable(args[0]) else (lambda func: func)
-)
-tvm_ffi.get_global_func = lambda _name: None
-sys.modules["tvm_ffi"] = tvm_ffi
-
-tvm = types.ModuleType("tvm")
-tvm.maca = lambda *_args, **_kwargs: types.SimpleNamespace(exist=False)
-tvm.target = types.ModuleType("tvm.target")
-tvm.target.Target = object
-sys.modules["tvm"] = tvm
-sys.modules["tvm.target"] = tvm.target
-
-tvm_base = types.ModuleType("tvm.base")
-tvm_base.py_str = lambda value: value.decode("utf-8") if isinstance(value, bytes) else str(value)
-sys.modules["tvm.base"] = tvm_base
-
-tvm_contrib = types.ModuleType("tvm.contrib")
-tvm_contrib.__path__ = []
-sys.modules["tvm.contrib"] = tvm_contrib
-
-tvm_contrib_utils = types.ModuleType("tvm.contrib.utils")
-tvm_contrib_utils.tempdir = lambda: None
-sys.modules["tvm.contrib.utils"] = tvm_contrib_utils
-
-spec = importlib.util.spec_from_file_location("tvm.contrib.mxcc", MXCC_PATH)
-mxcc = importlib.util.module_from_spec(spec)
-mxcc.__package__ = "tvm.contrib"
-sys.modules["tvm.contrib.mxcc"] = mxcc
-assert spec.loader is not None
-spec.loader.exec_module(mxcc)
+from tvm.contrib import mxcc
 
 
-class TestMXCCErrorMessage(unittest.TestCase):
+def test_error_message_includes_reproducible_command():
+    cmd = ["mxcc", "-device-obj", "-o", Path("/tmp/out.mcbin"), "/tmp/in.maca"]
+    source = 'extern "C" __global__ void broken() {}'
+    message = mxcc._format_mxcc_error(cmd, b"syntax error", source)
 
-    def test_error_message_includes_reproducible_command(self):
-        cmd = ["mxcc", "-device-obj", "-o", "/tmp/out.mcbin", "/tmp/in.maca"]
-        source = "extern \"C\" __global__ void broken() {}"
-        message = mxcc._format_mxcc_error(cmd, b"syntax error", source)
-
-        self.assertIn("MACA compilation failed.", message)
-        self.assertIn("mxcc -device-obj -o /tmp/out.mcbin /tmp/in.maca", message)
-        self.assertIn("syntax error", message)
-        self.assertIn(source, message)
+    assert "MACA compilation failed." in message
+    assert "mxcc -device-obj -o /tmp/out.mcbin /tmp/in.maca" in message
+    assert "syntax error" in message
+    assert source in message
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_error_message_replaces_non_utf8_output():
+    message = mxcc._format_mxcc_error(["mxcc"], b"\xff", "__kernel")
+
+    assert "Compiler output:" in message
+    assert "\ufffd" in message

--- a/tests/python/contrib/test_mxcc_error_message.py
+++ b/tests/python/contrib/test_mxcc_error_message.py
@@ -1,0 +1,59 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MXCC_PATH = REPO_ROOT / "python" / "tvm" / "contrib" / "mxcc.py"
+
+tvm_ffi = types.ModuleType("tvm_ffi")
+tvm_ffi.register_global_func = lambda *args, **kwargs: (
+    (lambda func: func) if args and callable(args[0]) else (lambda func: func)
+)
+tvm_ffi.get_global_func = lambda _name: None
+sys.modules["tvm_ffi"] = tvm_ffi
+
+tvm = types.ModuleType("tvm")
+tvm.maca = lambda *_args, **_kwargs: types.SimpleNamespace(exist=False)
+tvm.target = types.ModuleType("tvm.target")
+tvm.target.Target = object
+sys.modules["tvm"] = tvm
+sys.modules["tvm.target"] = tvm.target
+
+tvm_base = types.ModuleType("tvm.base")
+tvm_base.py_str = lambda value: value.decode("utf-8") if isinstance(value, bytes) else str(value)
+sys.modules["tvm.base"] = tvm_base
+
+tvm_contrib = types.ModuleType("tvm.contrib")
+tvm_contrib.__path__ = []
+sys.modules["tvm.contrib"] = tvm_contrib
+
+tvm_contrib_utils = types.ModuleType("tvm.contrib.utils")
+tvm_contrib_utils.tempdir = lambda: None
+sys.modules["tvm.contrib.utils"] = tvm_contrib_utils
+
+spec = importlib.util.spec_from_file_location("tvm.contrib.mxcc", MXCC_PATH)
+mxcc = importlib.util.module_from_spec(spec)
+mxcc.__package__ = "tvm.contrib"
+sys.modules["tvm.contrib.mxcc"] = mxcc
+assert spec.loader is not None
+spec.loader.exec_module(mxcc)
+
+
+class TestMXCCErrorMessage(unittest.TestCase):
+
+    def test_error_message_includes_reproducible_command(self):
+        cmd = ["mxcc", "-device-obj", "-o", "/tmp/out.mcbin", "/tmp/in.maca"]
+        source = "extern \"C\" __global__ void broken() {}"
+        message = mxcc._format_mxcc_error(cmd, b"syntax error", source)
+
+        self.assertIn("MACA compilation failed.", message)
+        self.assertIn("mxcc -device-obj -o /tmp/out.mcbin /tmp/in.maca", message)
+        self.assertIn("syntax error", message)
+        self.assertIn(source, message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
该 PR 在 mxcc 编译失败时输出完整命令和关键上下文，让维护者可以直接复现失败场景。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/mcTVM_new_toolchain_validation_20260608。提交分支：`mengz/report-mxcc-command-on-error`，目标仓库：`MetaX-MACA/mcTVM`。