### PR TITLE
从 MACA 路径解析 mxcc

### DIFF
--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -123,11 +123,10 @@ def compile_maca(
 
 def _find_mxcc():
     """Find mxcc from MACA_PATH or PATH."""
-    maca_path = os.environ.get("MACA_PATH")
-    if maca_path:
-        candidate = os.path.join(maca_path, "mxgpu_llvm", "bin", "mxcc")
-        if os.path.isfile(candidate):
-            return candidate
+    maca_path = os.environ.get("MACA_PATH", "/opt/maca")
+    candidate = os.path.join(maca_path, "mxgpu_llvm", "bin", "mxcc")
+    if os.path.isfile(candidate):
+        return candidate
     mxcc = shutil.which("mxcc")
     if mxcc:
         return mxcc

--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import as _abs
 
 import re
 import os
+import shutil
 import subprocess
 import warnings
 from typing import Tuple
@@ -81,7 +82,7 @@ def compile_maca(
         out_file.write(code)
 
     file_target = path_target if path_target else temp_target
-    cmd = ["mxcc"]
+    cmd = [_find_mxcc()]
     if target_format == "mcbin":
         cmd.append("-device-obj")
     elif target_format == "mcir":
@@ -118,6 +119,19 @@ def compile_maca(
         if not data:
             raise RuntimeError("Compilation error: empty result is generated")
         return data
+
+
+def _find_mxcc():
+    """Find mxcc from MACA_PATH or PATH."""
+    maca_path = os.environ.get("MACA_PATH")
+    if maca_path:
+        candidate = os.path.join(maca_path, "mxgpu_llvm", "bin", "mxcc")
+        if os.path.isfile(candidate):
+            return candidate
+    mxcc = shutil.which("mxcc")
+    if mxcc:
+        return mxcc
+    raise RuntimeError("Cannot find mxcc. Set MACA_PATH or add mxcc to PATH.")
 
 
 def parse_compute_version(compute_version):

--- a/tests/python/contrib/test_mxcc_compiler.py
+++ b/tests/python/contrib/test_mxcc_compiler.py
@@ -1,68 +1,31 @@
-import importlib.util
 import os
-import sys
-import types
-import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-MXCC_PATH = REPO_ROOT / "python" / "tvm" / "contrib" / "mxcc.py"
+from tvm.contrib import mxcc
 
 
-def _register_global_func(*args, **_kwargs):
-    if args and callable(args[0]):
-        return args[0]
-    return lambda fn: fn
+def test_find_mxcc_from_maca_path():
+    with TemporaryDirectory() as tmp_dir:
+        maca_path = Path(tmp_dir)
+        compiler = maca_path / "mxgpu_llvm" / "bin" / "mxcc"
+        compiler.parent.mkdir(parents=True)
+        compiler.write_text("#!/bin/sh\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"MACA_PATH": str(maca_path)}, clear=True):
+            assert mxcc._find_mxcc() == str(compiler)
 
 
-tvm_ffi = types.SimpleNamespace(register_global_func=_register_global_func)
-tvm = types.ModuleType("tvm")
-tvm.target = types.SimpleNamespace(Target=types.SimpleNamespace(current=lambda: None))
-tvm.maca = lambda *_args, **_kwargs: types.SimpleNamespace(exist=False)
-tvm.__path__ = []
-tvm_contrib = types.ModuleType("tvm.contrib")
-tvm_contrib.__path__ = []
-tvm_target = types.ModuleType("tvm.target")
-tvm_target.Target = object
-tvm_base = types.ModuleType("tvm.base")
-tvm_base.py_str = lambda value: value.decode("utf-8")
-tvm_contrib_utils = types.ModuleType("tvm.contrib.utils")
-tvm_contrib_utils.tempdir = lambda: None
-
-sys.modules.setdefault("tvm_ffi", tvm_ffi)
-sys.modules.setdefault("tvm", tvm)
-sys.modules.setdefault("tvm.contrib", tvm_contrib)
-sys.modules.setdefault("tvm.target", tvm_target)
-sys.modules.setdefault("tvm.base", tvm_base)
-sys.modules.setdefault("tvm.contrib.utils", tvm_contrib_utils)
-
-spec = importlib.util.spec_from_file_location("tvm.contrib.mxcc", MXCC_PATH)
-mxcc = importlib.util.module_from_spec(spec)
-mxcc.__package__ = "tvm.contrib"
-sys.modules["tvm.contrib.mxcc"] = mxcc
-assert spec.loader is not None
-spec.loader.exec_module(mxcc)
+def test_find_mxcc_from_default_maca_path():
+    default_compiler = "/opt/maca/mxgpu_llvm/bin/mxcc"
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("tvm.contrib.mxcc.os.path.isfile", return_value=True):
+            assert mxcc._find_mxcc() == default_compiler
 
 
-class MxccCompilerTest(unittest.TestCase):
-    def test_find_mxcc_from_maca_path(self):
-        with TemporaryDirectory() as tmp_dir:
-            maca_path = Path(tmp_dir)
-            compiler = maca_path / "mxgpu_llvm" / "bin" / "mxcc"
-            compiler.parent.mkdir(parents=True)
-            compiler.write_text("#!/bin/sh\n", encoding="utf-8")
-
-            with patch.dict(os.environ, {"MACA_PATH": str(maca_path)}, clear=True):
-                self.assertEqual(mxcc._find_mxcc(), str(compiler))
-
-    def test_find_mxcc_from_path(self):
-        with patch.dict(os.environ, {}, clear=True):
+def test_find_mxcc_from_path():
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("tvm.contrib.mxcc.os.path.isfile", return_value=False):
             with patch.object(mxcc.shutil, "which", return_value="/usr/bin/mxcc"):
-                self.assertEqual(mxcc._find_mxcc(), "/usr/bin/mxcc")
-
-
-if __name__ == "__main__":
-    unittest.main()
+                assert mxcc._find_mxcc() == "/usr/bin/mxcc"

--- a/tests/python/contrib/test_mxcc_compiler.py
+++ b/tests/python/contrib/test_mxcc_compiler.py
@@ -1,0 +1,68 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MXCC_PATH = REPO_ROOT / "python" / "tvm" / "contrib" / "mxcc.py"
+
+
+def _register_global_func(*args, **_kwargs):
+    if args and callable(args[0]):
+        return args[0]
+    return lambda fn: fn
+
+
+tvm_ffi = types.SimpleNamespace(register_global_func=_register_global_func)
+tvm = types.ModuleType("tvm")
+tvm.target = types.SimpleNamespace(Target=types.SimpleNamespace(current=lambda: None))
+tvm.maca = lambda *_args, **_kwargs: types.SimpleNamespace(exist=False)
+tvm.__path__ = []
+tvm_contrib = types.ModuleType("tvm.contrib")
+tvm_contrib.__path__ = []
+tvm_target = types.ModuleType("tvm.target")
+tvm_target.Target = object
+tvm_base = types.ModuleType("tvm.base")
+tvm_base.py_str = lambda value: value.decode("utf-8")
+tvm_contrib_utils = types.ModuleType("tvm.contrib.utils")
+tvm_contrib_utils.tempdir = lambda: None
+
+sys.modules.setdefault("tvm_ffi", tvm_ffi)
+sys.modules.setdefault("tvm", tvm)
+sys.modules.setdefault("tvm.contrib", tvm_contrib)
+sys.modules.setdefault("tvm.target", tvm_target)
+sys.modules.setdefault("tvm.base", tvm_base)
+sys.modules.setdefault("tvm.contrib.utils", tvm_contrib_utils)
+
+spec = importlib.util.spec_from_file_location("tvm.contrib.mxcc", MXCC_PATH)
+mxcc = importlib.util.module_from_spec(spec)
+mxcc.__package__ = "tvm.contrib"
+sys.modules["tvm.contrib.mxcc"] = mxcc
+assert spec.loader is not None
+spec.loader.exec_module(mxcc)
+
+
+class MxccCompilerTest(unittest.TestCase):
+    def test_find_mxcc_from_maca_path(self):
+        with TemporaryDirectory() as tmp_dir:
+            maca_path = Path(tmp_dir)
+            compiler = maca_path / "mxgpu_llvm" / "bin" / "mxcc"
+            compiler.parent.mkdir(parents=True)
+            compiler.write_text("#!/bin/sh\n", encoding="utf-8")
+
+            with patch.dict(os.environ, {"MACA_PATH": str(maca_path)}, clear=True):
+                self.assertEqual(mxcc._find_mxcc(), str(compiler))
+
+    def test_find_mxcc_from_path(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(mxcc.shutil, "which", return_value="/usr/bin/mxcc"):
+                self.assertEqual(mxcc._find_mxcc(), "/usr/bin/mxcc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
该 PR 增加从 MACA 安装目录解析 mxcc 的逻辑，提升容器内工具链布局变化时的兼容性。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/mcTVM_new_toolchain_validation_20260608。提交分支：`mengz/resolve-mxcc-from-maca-path`，目标仓库：`MetaX-MACA/mcTVM`。