### PR TITLE
支持环境变量指定 MACA 架构

### DIFF
--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -188,7 +188,7 @@ def have_fp16(compute_version):
 
 
 @tvm_ffi.register_global_func("tvm_callback_maca_get_arch")
-def get_maca_arch(maca_path="/opt/maca"):
+def get_maca_arch(maca_path=None):
     """Utility function to get the MetaX GPU architecture
 
     Parameters
@@ -202,6 +202,7 @@ def get_maca_arch(maca_path="/opt/maca"):
         The MetaX GPU architecture
     """
     gpu_arch = "xcore1000"
+    maca_path = maca_path or os.environ.get("MACA_PATH", "/opt/maca")
     # check if maca is installed
     if not os.path.exists(maca_path):
         print("MACA not detected, using default xcore1000")
@@ -210,10 +211,7 @@ def get_maca_arch(maca_path="/opt/maca"):
         # Execute macainfo command
         macainfo_output = subprocess.check_output([f"{maca_path}/bin/macainfo"]).decode("utf-8")
 
-        # Use regex to match the "Name" field
-        match = re.search(r"Name:\s+(XCORE\d+[a-zA-Z]*)", macainfo_output)
-        if match:
-            gpu_arch = match.group(1)
+        gpu_arch = _parse_macainfo_arch(macainfo_output) or gpu_arch
         return gpu_arch.lower()
     except subprocess.CalledProcessError:
         print(
@@ -222,6 +220,12 @@ def get_maca_arch(maca_path="/opt/maca"):
                     using default {gpu_arch}."
         )
         return gpu_arch
+
+
+def _parse_macainfo_arch(macainfo_output):
+    """Parse MetaX GPU architecture from macainfo output."""
+    match = re.search(r"Name:\s+(XCORE\d+[a-zA-Z]*)", macainfo_output)
+    return match.group(1) if match else None
 
 
 def find_maca_path():

--- a/tests/python/contrib/test_mxcc_arch.py
+++ b/tests/python/contrib/test_mxcc_arch.py
@@ -1,0 +1,71 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MXCC_PATH = REPO_ROOT / "python" / "tvm" / "contrib" / "mxcc.py"
+
+
+def _register_global_func(*args, **_kwargs):
+    if args and callable(args[0]):
+        return args[0]
+    return lambda fn: fn
+
+
+tvm_ffi = types.SimpleNamespace(register_global_func=_register_global_func)
+tvm = types.ModuleType("tvm")
+tvm.target = types.SimpleNamespace(Target=types.SimpleNamespace(current=lambda: None))
+tvm.maca = lambda *_args, **_kwargs: types.SimpleNamespace(exist=False)
+tvm.__path__ = []
+tvm_contrib = types.ModuleType("tvm.contrib")
+tvm_contrib.__path__ = []
+tvm_target = types.ModuleType("tvm.target")
+tvm_target.Target = object
+tvm_base = types.ModuleType("tvm.base")
+tvm_base.py_str = lambda value: value.decode("utf-8")
+tvm_contrib_utils = types.ModuleType("tvm.contrib.utils")
+tvm_contrib_utils.tempdir = lambda: None
+
+sys.modules.setdefault("tvm_ffi", tvm_ffi)
+sys.modules.setdefault("tvm", tvm)
+sys.modules.setdefault("tvm.contrib", tvm_contrib)
+sys.modules.setdefault("tvm.target", tvm_target)
+sys.modules.setdefault("tvm.base", tvm_base)
+sys.modules.setdefault("tvm.contrib.utils", tvm_contrib_utils)
+
+spec = importlib.util.spec_from_file_location("tvm.contrib.mxcc", MXCC_PATH)
+mxcc = importlib.util.module_from_spec(spec)
+mxcc.__package__ = "tvm.contrib"
+sys.modules["tvm.contrib.mxcc"] = mxcc
+assert spec.loader is not None
+spec.loader.exec_module(mxcc)
+
+
+class MxccArchTest(unittest.TestCase):
+    def test_parse_macainfo_arch(self):
+        self.assertEqual(mxcc._parse_macainfo_arch("Name: XCORE1000\n"), "XCORE1000")
+
+    def test_get_maca_arch_uses_maca_path_env(self):
+        with TemporaryDirectory() as tmp_dir:
+            maca_path = Path(tmp_dir)
+            (maca_path / "bin").mkdir()
+            (maca_path / "bin" / "macainfo").write_text("", encoding="utf-8")
+            with patch.dict(os.environ, {"MACA_PATH": str(maca_path)}):
+                with patch.object(
+                    mxcc.subprocess,
+                    "check_output",
+                    return_value=b"Name: XCORE2000\n",
+                ) as check_output:
+                    self.assertEqual(mxcc.get_maca_arch(), "xcore2000")
+
+            check_output.assert_called_once_with([f"{maca_path}/bin/macainfo"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
该 PR 支持通过环境变量指定 MACA 目标架构，使同一套源码更容易在不同沐曦设备和测试镜像间切换。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/mcTVM_new_toolchain_validation_20260608。提交分支：`mengz/use-env-maca-arch`，目标仓库：`MetaX-MACA/mcTVM`。