### PR TITLE
[MACA] Improve target-aware compilation, SDK integration, and Relax coverage

### DIFF
--- a/python/tvm/contrib/mxcc.py
+++ b/python/tvm/contrib/mxcc.py
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Compatibility wrapper for the MACA compiler helper."""
+
+from tvm.support.mxcc import *  # noqa: F403

--- a/python/tvm/support/mxcc.py
+++ b/python/tvm/support/mxcc.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import as _abs
 
 import os
 import re
+import shutil
 import subprocess
 
 import tvm_ffi
@@ -72,6 +73,16 @@ def _target_maca_arch(target):
     return _normalize_maca_arch(mcpu)
 
 
+def _find_mxcc():
+    """Find mxcc using the configured MACA SDK before PATH."""
+    if maca_path := os.environ.get("MACA_PATH"):
+        return os.path.join(maca_path, "mxgpu_llvm", "bin", "mxcc")
+    if mxcc_path := shutil.which("mxcc"):
+        return mxcc_path
+    default_mxcc = "/opt/maca/mxgpu_llvm/bin/mxcc"
+    return default_mxcc if os.path.isfile(default_mxcc) else "mxcc"
+
+
 def compile_maca(code, target_format="mcbin", arch=None, options=None, path_target=None):  # pylint: disable=unused-argument
     """Compile maca code with MXCC from env.
 
@@ -120,7 +131,7 @@ def compile_maca(code, target_format="mcbin", arch=None, options=None, path_targ
         out_file.write(code)
 
     file_target = path_target if path_target else temp_target
-    cmd = ["mxcc"]
+    cmd = [_find_mxcc()]
     if target_format == "mcbin":
         cmd.append("-device-obj")
     elif target_format == "mcir":
@@ -230,12 +241,12 @@ def have_bf16(compute_version):  # pylint: disable=unused-argument
     return True
 
 
-def get_maca_arch(maca_path="/opt/maca"):
+def get_maca_arch(maca_path=None):
     """Utility function to get the MetaX GPU architecture
 
     Parameters
     ----------
-    maca_path : str
+    maca_path : str, optional
         The path to maca installation directory
 
     Returns

--- a/python/tvm/support/mxcc.py
+++ b/python/tvm/support/mxcc.py
@@ -230,7 +230,6 @@ def have_bf16(compute_version):  # pylint: disable=unused-argument
     return True
 
 
-@tvm_ffi.register_global_func("tvm_callback_maca_get_arch")
 def get_maca_arch(maca_path="/opt/maca"):
     """Utility function to get the MetaX GPU architecture
 
@@ -272,6 +271,9 @@ def get_maca_arch(maca_path="/opt/maca"):
                     using default {gpu_arch}."
         )
         return gpu_arch
+
+
+tvm_ffi.register_global_func("tvm_callback_maca_get_arch", get_maca_arch)
 
 
 def find_maca_path():

--- a/python/tvm/support/mxcc.py
+++ b/python/tvm/support/mxcc.py
@@ -28,6 +28,50 @@ import tvm
 from tvm.support import utils
 
 
+def _normalize_maca_arch(arch):
+    """Normalize MACA architecture names to mxcc offload-arch form."""
+    if arch is None:
+        return None
+    arch = str(arch).strip().lower()
+    if not arch:
+        return None
+    if arch.startswith("xcore"):
+        return arch
+    if re.fullmatch(r"\d+[a-zA-Z]*", arch):
+        return "xcore" + arch
+    raise ValueError(f"Invalid MACA architecture: {arch}")
+
+
+def _maca_compute_version_from_arch(arch):
+    """Convert xcore architecture names to compute version strings."""
+    arch = _normalize_maca_arch(arch)
+    if arch is None:
+        return None
+    match = re.match(r"xcore(\d+)", arch)
+    if not match:
+        raise ValueError(f"Invalid MACA architecture: {arch}")
+    digits = match.group(1)
+    if len(digits) >= 4:
+        major = int(digits[:-2])
+        minor = int(digits[-2:])
+    elif len(digits) == 3:
+        major = int(digits[:1])
+        minor = int(digits[1:])
+    else:
+        major = int(digits)
+        minor = 0
+    return f"{major}.{minor}"
+
+
+def _target_maca_arch(target):
+    """Extract a normalized MACA architecture from a Target object."""
+    target = target or tvm.target.Target.current()
+    if target is None:
+        return None
+    mcpu = getattr(target, "mcpu", None)
+    return _normalize_maca_arch(mcpu)
+
+
 def compile_maca(code, target_format="mcbin", arch=None, options=None, path_target=None):  # pylint: disable=unused-argument
     """Compile maca code with MXCC from env.
 
@@ -83,6 +127,9 @@ def compile_maca(code, target_format="mcbin", arch=None, options=None, path_targ
         cmd.extend(["-emit-llvm", "-maca-device-only"])
     else:
         cmd.append("-fatbin")
+    arch = _normalize_maca_arch(arch)
+    if arch:
+        cmd.append(f"-offload-arch={arch}")
     cmd.append("-O3")
     if kernels_output_dir is not None:
         cmd += ["-lineinfo"]
@@ -250,9 +297,9 @@ def find_maca_path():
 
 
 @tvm_ffi.register_global_func
-def tvm_callback_maca_compile(code, target):  # pylint: disable=unused-argument
+def tvm_callback_maca_compile(code, target):
     """use mxcc to generate fatbin code for better optimization"""
-    dev_obj = compile_maca(code, target_format="mcbin")
+    dev_obj = compile_maca(code, target_format="mcbin", arch=_target_maca_arch(target))
     return dev_obj
 
 
@@ -277,12 +324,7 @@ def get_target_compute_version(target=None):
     # 2. Target.current()
     target = target or tvm.target.Target.current()
     if target and target.mcpu:
-        arch = target.mcpu[5:]
-        major = arch[:2]
-        minor = arch[2:]
-        if minor == "00":
-            minor = "0"
-        return major + "." + minor
+        return _maca_compute_version_from_arch(target.mcpu)
 
     # 3. GPU compute version
     if tvm.maca(0).exist:

--- a/src/backend/maca/codegen/build_maca_on.cc
+++ b/src/backend/maca/codegen/build_maca_on.cc
@@ -186,18 +186,17 @@ ffi::Module BuildMACA(IRModule mod, Target target) {
   }
   std::string fmt = "mcir";
   std::string mcir;
-  auto f_enter = ffi::Function::GetGlobal("target.TargetEnterScope");
-  (*f_enter)(target);
-  if (auto f = ffi::Function::GetGlobal("tvm_callback_maca_compile")) {
-    mcir = (*f)(code, target).cast<std::string>();
-    // Dirty matching to check mcir vs mcbin.
-    // TODO(tqchen) more reliable checks
-    if (mcir[0] != '/') fmt = "mcbin";
-  } else {
-    mcir = MCRTCCompile(code, cg.need_include_path());
+  {
+    With<Target> target_scope(target);
+    if (auto f = ffi::Function::GetGlobal("tvm_callback_maca_compile")) {
+      mcir = (*f)(code, target).cast<std::string>();
+      // Dirty matching to check mcir vs mcbin.
+      // TODO(tqchen) more reliable checks
+      if (mcir[0] != '/') fmt = "mcbin";
+    } else {
+      mcir = MCRTCCompile(code, cg.need_include_path());
+    }
   }
-  auto f_exit = ffi::Function::GetGlobal("target.TargetExitScope");
-  (*f_exit)(target);
   return ::tvm::target::MACAModuleCreateWithFallback(ffi::Bytes(std::move(mcir)), ffi::String(fmt),
                                                      ExtractFuncInfo(mod), ffi::String(code));
 }

--- a/src/s_tir/meta_schedule/space_generator/space_generator.cc
+++ b/src/s_tir/meta_schedule/space_generator/space_generator.cc
@@ -19,12 +19,58 @@
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/runtime/logging.h>
 
+#include <cctype>
+#include <stdexcept>
+#include <string>
+
 #include "../../../target/canonicalizer/llvm/arm_aprofile.h"
 #include "../utils.h"
 
 namespace tvm {
 namespace s_tir {
 namespace meta_schedule {
+
+namespace {
+
+bool MACATargetSupportsWMMA(const Target& target) {
+  ffi::Optional<ffi::String> opt_mcpu = target->GetAttr<ffi::String>("mcpu");
+  if (!opt_mcpu) {
+    return false;
+  }
+
+  std::string arch = opt_mcpu.value();
+  for (char& ch : arch) {
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  }
+  if (support::StartsWith(arch, "xcore")) {
+    arch = arch.substr(5);
+  }
+
+  size_t digit_count = 0;
+  while (digit_count < arch.size() && std::isdigit(static_cast<unsigned char>(arch[digit_count]))) {
+    ++digit_count;
+  }
+  if (digit_count == 0) {
+    LOG(WARNING) << "ValueError: Unable to parse MACA target mcpu: " << opt_mcpu.value();
+    return false;
+  }
+
+  std::string version = arch.substr(0, digit_count);
+  try {
+    int arch_version = std::stoi(version);
+    // Keep this as an explicit allowlist until MACA exposes a queryable WMMA capability.
+    return arch_version == 1000;
+  } catch (const std::invalid_argument& e) {
+    LOG(WARNING) << "ValueError: Unable to parse MACA target mcpu: " << opt_mcpu.value()
+                 << ". Details: " << e.what();
+  } catch (const std::out_of_range& e) {
+    LOG(WARNING) << "ValueError: MACA target mcpu is out of range: " << opt_mcpu.value()
+                 << ". Details: " << e.what();
+  }
+  return false;
+}
+
+}  // namespace
 
 ffi::String GetRuleKindFromTarget(const Target& target) {
   if (target->kind->name == "llvm") {
@@ -78,7 +124,10 @@ ffi::String GetRuleKindFromTarget(const Target& target) {
     return "cuda";
   }
   if (target->kind->name == "maca") {
-    return "maca-wmma";
+    if (MACATargetSupportsWMMA(target)) {
+      return "maca-wmma";
+    }
+    return "maca";
   }
 
   if (IsGPUTarget(target->kind->name)) {
@@ -227,6 +276,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def_method("s_tir.meta_schedule.SpaceGeneratorGenerateDesignSpace",
                   &SpaceGeneratorNode::GenerateDesignSpace)
       .def("s_tir.meta_schedule.SpaceGeneratorPySpaceGenerator", SpaceGenerator::PySpaceGenerator)
+      .def("s_tir.meta_schedule.GetRuleKindFromTarget", GetRuleKindFromTarget)
       .def_method("s_tir.meta_schedule.SpaceGeneratorClone", &SpaceGeneratorNode::Clone);
 }
 

--- a/tests/python/contrib/test_mxcc_arch.py
+++ b/tests/python/contrib/test_mxcc_arch.py
@@ -57,9 +57,10 @@ class TestMacaArchDetection(unittest.TestCase):
                 with patch(
                     "subprocess.check_output",
                     return_value=b"Name: XCORE1800\n",
-                ):
+                ) as check_output:
                     arch = mxcc.get_maca_arch()
                     self.assertEqual(arch, "xcore1800")
+                    check_output.assert_called_once_with(["/custom/maca/bin/macainfo"])
 
     def test_oserror_is_caught(self):
         """Test OSError (e.g. missing binary) is caught gracefully"""
@@ -130,6 +131,33 @@ class TestMacaArchDetection(unittest.TestCase):
                 )
 
         self.assertIn("-offload-arch=xcore2000", seen["cmd"])
+
+    def test_compile_maca_uses_maca_path(self):
+        """Test compile_maca finds mxcc under the configured MACA SDK"""
+        seen = {}
+
+        class FakePopen:
+            def __init__(self, cmd, stdout=None, stderr=None):
+                seen["cmd"] = list(cmd)
+                out = cmd[cmd.index("-o") + 1]
+                with open(out, "wb") as f:
+                    f.write(b"fake-mcbin")
+                self.returncode = 0
+
+            def communicate(self):
+                return (b"", None)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path_target = os.path.join(temp_dir, "tvm_fake_maca.mcbin")
+            with patch.dict(os.environ, {"MACA_PATH": "/custom/maca"}, clear=True):
+                with patch("subprocess.Popen", FakePopen):
+                    mxcc.compile_maca(
+                        "__global__ void tvm_kernel() {}",
+                        path_target=path_target,
+                    )
+
+        expected_mxcc = "/custom/maca/mxgpu_llvm/bin/mxcc"
+        self.assertEqual(seen["cmd"][0], expected_mxcc)
 
     def test_callback_maca_compile_uses_target_mcpu(self):
         """Test tvm_callback_maca_compile forwards target mcpu to mxcc"""

--- a/tests/python/contrib/test_mxcc_arch.py
+++ b/tests/python/contrib/test_mxcc_arch.py
@@ -23,7 +23,7 @@ import unittest
 from unittest.mock import patch
 
 import tvm
-from tvm.support import mxcc
+from tvm.contrib import mxcc
 
 
 class TestMacaArchDetection(unittest.TestCase):

--- a/tests/python/contrib/test_mxcc_arch.py
+++ b/tests/python/contrib/test_mxcc_arch.py
@@ -22,6 +22,8 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+import tvm_ffi
+
 import tvm
 from tvm.contrib import mxcc
 
@@ -149,6 +151,24 @@ class TestMacaArchDetection(unittest.TestCase):
             mxcc.tvm_callback_maca_compile("__global__ void tvm_kernel() {}", target)
 
         self.assertIn("-offload-arch=xcore1800", seen["cmd"])
+
+    def test_compile_failure_restores_target_scope(self):
+        """Test a failed MACA compile callback does not leak its target scope"""
+        callback_name = "tvm_callback_maca_compile"
+        original_callback = tvm_ffi.get_global_func(callback_name)
+
+        def failing_compile(code, target):  # pylint: disable=unused-argument
+            raise RuntimeError("intentional MACA compile failure")
+
+        tvm_ffi.register_global_func(callback_name, failing_compile, override=True)
+        try:
+            target = tvm.target.Target({"kind": "maca", "mcpu": "xcore1000"})
+            build_maca = tvm_ffi.get_global_func("target.build.maca")
+            with self.assertRaisesRegex(RuntimeError, "intentional MACA compile failure"):
+                build_maca(tvm.IRModule(), target)
+            self.assertIsNone(tvm.target.Target.current(allow_none=True))
+        finally:
+            tvm_ffi.register_global_func(callback_name, original_callback, override=True)
 
     def test_target_compute_version_parses_maca_arch(self):
         """Test xcore architecture is converted to MACA compute version"""

--- a/tests/python/contrib/test_mxcc_arch.py
+++ b/tests/python/contrib/test_mxcc_arch.py
@@ -18,9 +18,11 @@
 
 import os
 import subprocess
+import tempfile
 import unittest
 from unittest.mock import patch
 
+import tvm
 from tvm.support import mxcc
 
 
@@ -36,14 +38,14 @@ class TestMacaArchDetection(unittest.TestCase):
     def test_env_maca_arch_overrides_maca_path(self):
         """Test MACA_ARCH takes priority even when maca_path is given"""
         with patch.dict(os.environ, {"MACA_ARCH": "xcore3000"}):
-            arch = mxcc.get_maca_arch("/nonexistent")
+            arch = mxcc.get_maca_arch(maca_path="/nonexistent")
             self.assertEqual(arch, "xcore3000")
 
     def test_maca_not_installed_default(self):
         """Test default arch is returned when MACA is not installed"""
         with patch.dict(os.environ, {}, clear=True):
             with patch("os.path.exists", return_value=False):
-                arch = mxcc.get_maca_arch("/nonexistent")
+                arch = mxcc.get_maca_arch(maca_path="/nonexistent")
                 self.assertEqual(arch, "xcore1000")
 
     def test_maca_path_env_var(self):
@@ -65,7 +67,7 @@ class TestMacaArchDetection(unittest.TestCase):
                     "subprocess.check_output",
                     side_effect=OSError("macainfo binary not found"),
                 ):
-                    arch = mxcc.get_maca_arch("/valid/path")
+                    arch = mxcc.get_maca_arch(maca_path="/valid/path")
                     self.assertEqual(arch, "xcore1000")
 
     def test_calledprocesserror_is_caught(self):
@@ -76,7 +78,7 @@ class TestMacaArchDetection(unittest.TestCase):
                     "subprocess.check_output",
                     side_effect=subprocess.CalledProcessError(1, "macainfo"),
                 ):
-                    arch = mxcc.get_maca_arch("/valid/path")
+                    arch = mxcc.get_maca_arch(maca_path="/valid/path")
                     self.assertEqual(arch, "xcore1000")
 
     def test_macainfo_parsing(self):
@@ -87,7 +89,7 @@ class TestMacaArchDetection(unittest.TestCase):
                     "subprocess.check_output",
                     return_value=b"Name: XCORE2000\n",
                 ):
-                    arch = mxcc.get_maca_arch("/valid/path")
+                    arch = mxcc.get_maca_arch(maca_path="/valid/path")
                     self.assertEqual(arch, "xcore2000")
 
     def test_macainfo_parsing_no_match(self):
@@ -98,8 +100,62 @@ class TestMacaArchDetection(unittest.TestCase):
                     "subprocess.check_output",
                     return_value=b"Name: UNKNOWN_DEVICE\n",
                 ):
-                    arch = mxcc.get_maca_arch("/valid/path")
+                    arch = mxcc.get_maca_arch(maca_path="/valid/path")
                     self.assertEqual(arch, "xcore1000")
+
+    def test_compile_maca_uses_arch(self):
+        """Test compile_maca forwards explicit arch to mxcc"""
+        seen = {}
+
+        class FakePopen:
+            def __init__(self, cmd, stdout=None, stderr=None):
+                seen["cmd"] = list(cmd)
+                out = cmd[cmd.index("-o") + 1]
+                with open(out, "wb") as f:
+                    f.write(b"fake-mcbin")
+                self.returncode = 0
+
+            def communicate(self):
+                return (b"", None)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path_target = os.path.join(temp_dir, "tvm_fake_maca.mcbin")
+            with patch("subprocess.Popen", FakePopen):
+                mxcc.compile_maca(
+                    "__global__ void tvm_kernel() {}",
+                    arch="xcore2000",
+                    path_target=path_target,
+                )
+
+        self.assertIn("-offload-arch=xcore2000", seen["cmd"])
+
+    def test_callback_maca_compile_uses_target_mcpu(self):
+        """Test tvm_callback_maca_compile forwards target mcpu to mxcc"""
+        seen = {}
+
+        class FakePopen:
+            def __init__(self, cmd, stdout=None, stderr=None):
+                seen["cmd"] = list(cmd)
+                out = cmd[cmd.index("-o") + 1]
+                with open(out, "wb") as f:
+                    f.write(b"fake-mcbin")
+                self.returncode = 0
+
+            def communicate(self):
+                return (b"", None)
+
+        target = tvm.target.Target({"kind": "maca", "mcpu": "xcore1800"})
+        with patch("subprocess.Popen", FakePopen):
+            mxcc.tvm_callback_maca_compile("__global__ void tvm_kernel() {}", target)
+
+        self.assertIn("-offload-arch=xcore1800", seen["cmd"])
+
+    def test_target_compute_version_parses_maca_arch(self):
+        """Test xcore architecture is converted to MACA compute version"""
+        target = tvm.target.Target({"kind": "maca", "mcpu": "xcore1000"})
+        self.assertEqual(mxcc.get_target_compute_version(target), "10.0")
+        target = tvm.target.Target({"kind": "maca", "mcpu": "xcore700"})
+        self.assertEqual(mxcc.get_target_compute_version(target), "7.0")
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_backend_dispatch_sampling.py
+++ b/tests/python/relax/test_backend_dispatch_sampling.py
@@ -18,11 +18,14 @@
 # ruff: noqa: E501
 
 
+import numpy as np
+
 import tvm
 import tvm.script
 import tvm.testing
 from tvm.ir.base import assert_structural_equal
 from tvm.relax.backend import DispatchSampling
+from tvm.relax.backend.gpu_generic import gpu_multinomial_from_uniform
 from tvm.script import ir as I
 from tvm.script import relax as R
 from tvm.script import tirx as T
@@ -35,6 +38,20 @@ class MultiFromUniformModule:
         prob: R.Tensor((3, 5), "float32"),
         uniform_sample: R.Tensor((6, 1), "float32"),
         sample_indices: R.Tensor((6, 1), "int64"),
+    ):
+        with R.dataflow():
+            gv = R.multinomial_from_uniform(prob, uniform_sample, sample_indices, dtype="int64")
+            R.output(gv)
+        return gv
+
+
+@I.ir_module(s_tir=True)
+class MultiFromUniformInt32IndicesModule:
+    @R.function
+    def foo(
+        prob: R.Tensor((3, 5), "float32"),
+        uniform_sample: R.Tensor((6, 1), "float32"),
+        sample_indices: R.Tensor((6, 1), "int32"),
     ):
         with R.dataflow():
             gv = R.multinomial_from_uniform(prob, uniform_sample, sample_indices, dtype="int64")
@@ -197,6 +214,54 @@ def test_dispatch_multinomial_from_uniform_gpu():
         mod = DispatchSampling()(MultiFromUniformModule)
 
     assert_structural_equal(mod, Expected)
+
+
+def test_dispatch_multinomial_from_uniform_maca_int32_indices():
+    with tvm.target.Target("maca"):
+        mod = DispatchSampling()(MultiFromUniformInt32IndicesModule)
+
+    kernel = mod["parallel_sampling_from_prob"]
+    assert kernel.buffer_map[kernel.params[2]].dtype == "int32"
+
+    row_idx_bindings = []
+
+    def collect_row_idx_binding(node):
+        if isinstance(node, tvm.tirx.Bind) and node.var.name == "row_idx":
+            row_idx_bindings.append(node)
+
+    tvm.tirx.stmt_functor.post_order_visit(kernel.body, collect_row_idx_binding)
+    assert len(row_idx_bindings) == 1
+    assert isinstance(row_idx_bindings[0].value, tvm.tirx.Cast)
+    assert row_idx_bindings[0].value.ty == tvm.ir.PrimType("int64")
+
+
+@tvm.testing.requires_gpu
+@tvm.testing.requires_maca
+def test_maca_multinomial_from_uniform_int32_indices():
+    with tvm.target.Target("maca"):
+        kernel = gpu_multinomial_from_uniform(sample_indices_dtype="int32")
+    func = tvm.compile(kernel, target="maca")
+
+    prob = np.array(
+        [
+            [0.10, 0.20, 0.30, 0.15, 0.25],
+            [0.00, 0.50, 0.00, 0.50, 0.00],
+            [0.40, 0.10, 0.10, 0.10, 0.30],
+        ],
+        dtype="float32",
+    )
+    uniform_sample = np.array([[0.05], [0.49], [0.55], [0.95], [0.70], [0.75]], dtype="float32")
+    sample_indices = np.array([[0], [1], [2], [2], [0], [1]], dtype="int32")
+    expected = np.array([[0], [1], [2], [4], [3], [3]], dtype="int64")
+
+    dev = tvm.maca(0)
+    prob_dev = tvm.runtime.tensor(prob, dev)
+    uniform_sample_dev = tvm.runtime.tensor(uniform_sample, dev)
+    sample_indices_dev = tvm.runtime.tensor(sample_indices, dev)
+    output_dev = tvm.runtime.empty(expected.shape, "int64", dev)
+    func(prob_dev, uniform_sample_dev, sample_indices_dev, output_dev)
+
+    tvm.testing.assert_allclose(output_dev.numpy(), expected)
 
 
 if __name__ == "__main__":

--- a/tests/python/s_tir/meta_schedule/test_meta_schedule_space_generator.py
+++ b/tests/python/s_tir/meta_schedule/test_meta_schedule_space_generator.py
@@ -23,6 +23,7 @@ import pytest
 
 import tvm
 import tvm.testing
+import tvm_ffi
 from tvm.ir.utils import derived_object
 from tvm.s_tir.meta_schedule.space_generator import (
     PySpaceGenerator,
@@ -69,6 +70,14 @@ def _check_correct(schedule: Schedule):
     trace = schedule.trace
     for inst in trace.decisions:
         assert math.prod(trace.decisions[inst]) == 1024
+
+
+def test_meta_schedule_maca_rule_kind_gates_wmma_by_mcpu():
+    get_rule_kind = tvm_ffi.get_global_func("s_tir.meta_schedule.GetRuleKindFromTarget")
+
+    assert get_rule_kind(tvm.target.Target({"kind": "maca", "mcpu": "xcore700"})) == "maca"
+    assert get_rule_kind(tvm.target.Target({"kind": "maca", "mcpu": "xcore800"})) == "maca"
+    assert get_rule_kind(tvm.target.Target({"kind": "maca", "mcpu": "xcore1000"})) == "maca-wmma"
 
 
 def test_meta_schedule_space_generator_schedule_fn():

--- a/tests/python/s_tir/meta_schedule/test_meta_schedule_space_generator.py
+++ b/tests/python/s_tir/meta_schedule/test_meta_schedule_space_generator.py
@@ -20,10 +20,10 @@
 import math
 
 import pytest
+import tvm_ffi
 
 import tvm
 import tvm.testing
-import tvm_ffi
 from tvm.ir.utils import derived_object
 from tvm.s_tir.meta_schedule.space_generator import (
     PySpaceGenerator,


### PR DESCRIPTION
This PR improves MACA backend correctness and integration:

  - Propagate `Target.mcpu` to `mxcc` and select generic or WMMA MetaSchedule rules by architecture.
  - Add the standard `tvm.contrib.mxcc` compatibility entry point.
  - Make MACA Target scope exception-safe with RAII.
  - Honor `MACA_PATH` when locating the `mxcc` compiler.
  - Add structural and real-device Relax tests for multinomial sampling with int32 row indices.

Validation:
  - TVM builds successfully with MACA enabled.
  - All 6 targeted MACA tests pass.
  - Verified real `mxcc` compilation, architecture-specific tuning rules, SDK discovery, Target restoration,
  and Relax sampling execution on a MACA device.