### PR TITLE
[MetaXGPU] Register the native rsqrt lowering for the MACA target

### DIFF
--- a/src/backend/maca/codegen/intrin_rule_maca.cc
+++ b/src/backend/maca/codegen/intrin_rule_maca.cc
@@ -236,6 +236,9 @@ TVM_REGISTER_OP("tirx.pow")
     .set_attr<FLowerIntrinsic>("maca.fastmath.FLowerIntrinsic", DispatchPureExtern<MACAFastMath>)
     .set_attr<FLowerIntrinsic>("maca.FLowerIntrinsic", DispatchPureExtern<MACAMath>);
 
+TVM_REGISTER_OP("tirx.rsqrt")
+    .set_attr<FLowerIntrinsic>("maca.FLowerIntrinsic", DispatchPureExtern<MACAMath>);
+
 TVM_REGISTER_OP("tirx.popcount")
     .set_attr<FLowerIntrinsic>("maca.FLowerIntrinsic", DispatchPureExtern<MACAPopcount>);
 

--- a/tests/python/codegen/test_target_codegen_maca_intrin.py
+++ b/tests/python/codegen/test_target_codegen_maca_intrin.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Codegen tests for the MACA intrinsic lowering rules."""
+
+import re
+
+import numpy as np
+import pytest
+
+import tvm
+import tvm.testing
+from tvm.script import tirx as T
+from tvm.testing import env
+
+VECTOR_N = 8
+
+
+def _compile_rsqrt():
+    @T.prim_func
+    def kernel(A: T.Buffer((VECTOR_N,), "float32"), B: T.Buffer((VECTOR_N,), "float32")):
+        T.func_attr({"global_symbol": "rsqrt_kernel", "tirx.noalias": True})
+        for i in T.thread_binding(VECTOR_N, thread="threadIdx.x"):
+            B[i] = T.rsqrt(A[i])
+
+    target = tvm.target.Target("maca")
+    mod = tvm.IRModule.from_expr(kernel.with_attr("target", target))
+    executable = tvm.compile(mod, target=target)
+    return executable, executable.mod.imports[0].inspect_source()
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+def test_rsqrt_lowers_to_the_native_intrinsic():
+    # Without a maca.FLowerIntrinsic registration, rsqrt falls back to the generic
+    # legalize rule (src/target/intrin_rule.cc:188), which rewrites it as 1 / sqrt(x).
+    _, source = _compile_rsqrt()
+
+    assert re.search(r"\brsqrtf\s*\(", source), source
+    assert not re.search(r"/\s*sqrtf\s*\(", source), source
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+def test_rsqrt_is_numerically_correct():
+    executable, _ = _compile_rsqrt()
+
+    dev = tvm.maca(0)
+    a = np.array([0.25, 0.5, 1.0, 2.0, 4.0, 9.0, 16.0, 100.0], dtype="float32")
+    tvm_a = tvm.runtime.tensor(a, device=dev)
+    out = tvm.runtime.empty((VECTOR_N,), "float32", dev)
+
+    executable(tvm_a, out)
+    dev.sync()
+
+    np.testing.assert_allclose(out.numpy(), 1.0 / np.sqrt(a), rtol=1e-5, atol=1e-6)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
## Problem

CUDA registers a hardware reciprocal square root for `tirx.rsqrt` (`intrin_rule_cuda.cc:242`). MACA registers nothing.

Without a target-specific `FLowerIntrinsic`, `rsqrt` falls back to the generic legalize rule (`src/target/intrin_rule.cc:188`), which rewrites it as `1 / sqrt(x)` — a reciprocal plus a square root, where MACA has a single instruction. Nothing warns, and `rsqrt` sits on the RMSNorm and LayerNorm hot paths.

## Changes

```cpp
TVM_REGISTER_OP("tirx.rsqrt")
    .set_attr<FLowerIntrinsic>("maca.FLowerIntrinsic", DispatchPureExtern<MACAMath>);
```

Seventeen test files in the tree mention `rsqrt` and none of them targets `maca`, so the registration comes with one that does. `tests/python/codegen/test_target_codegen_maca_intrin.py` asserts that `rsqrtf` appears in the generated device code and that `1 / sqrtf` does not, and checks the kernel's output against `1 / sqrt(x)`.

## Test Result

MetaX C500, MACA 3.5.3.20.

```
2 passed in 1.20s
```

Generated device code, before and after:

```c
B[i] = (1.000000e+00f / sqrtf(A[i]));   // dev
B[i] = rsqrtf(A[i]);                    // this PR
```

Dropping the registration and keeping the test:

```
1 failed, 1 passed
>   assert re.search(r"\brsqrtf\s*\(", source), source
E   assert None
```
