### PR TITLE
[MetaXGPU] Use ties-to-even rounding for tirx.round on the MACA target

### DIFF
--- a/src/backend/maca/codegen/intrin_rule_maca.cc
+++ b/src/backend/maca/codegen/intrin_rule_maca.cc
@@ -38,8 +38,11 @@ struct MACAMath {
     if (t.MatchesCode(DLDataTypeCode::kDLFloat)) {
       switch (t.bits()) {
         case 64:
+          // Use nearbyint (ties-to-even) for round to match constant-folding semantics.
+          if (name == "round") return "nearbyint";
           return name;
         case 32:
+          if (name == "round") return "nearbyintf";
           return name + 'f';
         case 16: {
           if (name == "fabs") {

--- a/tests/python/codegen/test_target_codegen_maca_round.py
+++ b/tests/python/codegen/test_target_codegen_maca_round.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Rounding semantics of tirx.round on the MACA target."""
+
+import re
+
+import numpy as np
+import pytest
+
+import tvm
+import tvm.testing
+from tvm.script import tirx as T
+from tvm.testing import env
+
+# Only halfway cases separate the two rules: roundf is ties-away-from-zero,
+# nearbyintf under the default mode is ties-to-even. Anything else rounds alike.
+TIES = np.array([0.5, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5, -3.5], dtype="float32")
+VECTOR_N = len(TIES)
+
+
+def _compile_round():
+    @T.prim_func
+    def kernel(A: T.Buffer((VECTOR_N,), "float32"), B: T.Buffer((VECTOR_N,), "float32")):
+        T.func_attr({"global_symbol": "round_kernel", "tirx.noalias": True})
+        for i in T.thread_binding(VECTOR_N, thread="threadIdx.x"):
+            B[i] = T.round(A[i])
+
+    target = tvm.target.Target("maca")
+    mod = tvm.IRModule.from_expr(kernel.with_attr("target", target))
+    executable = tvm.compile(mod, target=target)
+    return executable, executable.mod.imports[0].inspect_source()
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+def test_round_lowers_to_nearbyint():
+    _, source = _compile_round()
+
+    assert re.search(r"\bnearbyintf\s*\(", source), source
+    assert not re.search(r"(?<!nearbyint)\broundf\s*\(", source), source
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+def test_round_is_ties_to_even():
+    executable, _ = _compile_round()
+
+    dev = tvm.maca(0)
+    tvm_a = tvm.runtime.tensor(TIES, device=dev)
+    out = tvm.runtime.empty((VECTOR_N,), "float32", dev)
+    executable(tvm_a, out)
+    dev.sync()
+
+    # ties-to-even, which is what every other backend and TVM's own constant
+    # folding produce. roundf would give 1, 2, 3, 4, -1, -2, -3, -4.
+    expected = np.array([0.0, 2.0, 2.0, 4.0, -0.0, -2.0, -2.0, -4.0], dtype="float32")
+    np.testing.assert_array_equal(out.numpy(), expected)
+
+
+if __name__ == "__main__":
+    tvm.testing.main()


### PR DESCRIPTION
## Problem

`MACAMath` lowers `tirx.round` to `round` / `roundf`, which round halfway cases away from zero. Every other backend in the tree lowers it to nearbyint, which under the default rounding mode rounds halfway cases to even:

- `src/backend/cuda/codegen/intrin_rule_cuda.cc:41-45` returns `nearbyint` for fp64 and `nearbyintf` for fp32
- `src/target/llvm/intrin_rule_llvm.cc:91-93` dispatches `tirx.round` to `llvm::Intrinsic::nearbyint`

So the same graph rounds `0.5` to `1.0` on a MACA device and to `0.0` everywhere else, and a value that gets constant-folded at compile time disagrees with the same value computed on device. Only exact halfway inputs diverge, so this stays invisible under random test data.

fp16 is already correct: it maps to `hrint`, which is ties-to-even.

## Changes

`MACAMath` returns `nearbyint` for fp64 and `nearbyintf` for fp32, matching the CUDA rule it was forked from. `tirx.nearbyint` is unaffected — it already lowered to the same function.

## Test Plan

`tests/python/codegen/test_target_codegen_maca_round.py` on a MetaX C500 (MACA 3.5.3.20). Both cases feed the eight halfway values `±0.5, ±1.5, ±2.5, ±3.5`, which are the only inputs the two rules disagree on:

- the generated MACA source calls `nearbyintf` and does not call `roundf`
- the kernel returns `0, 2, 2, 4, -0, -2, -2, -4`

## Test Result

```
2 passed in 1.19s
```

Reverting the two lines in `intrin_rule_maca.cc` and rebuilding turns both cases red, so the test does exercise the changed lowering:

```
Mismatched elements: 4 / 8 (50%)
 [0]: 1.0 (ACTUAL), 0.0 (DESIRED)
 [2]: 3.0 (ACTUAL), 2.0 (DESIRED)
 [4]: -1.0 (ACTUAL), -0.0 (DESIRED)
 [6]: -3.0 (ACTUAL), -2.0 (DESIRED)
```
