### PR TITLE
[MetaXGPU] Align the MACA for-loop codegen with CUDA

### DIFF
--- a/src/backend/maca/codegen/codegen_maca.cc
+++ b/src/backend/maca/codegen/codegen_maca.cc
@@ -1264,6 +1264,16 @@ void CodeGenMACA::VisitStmt_(const AttrStmtNode* op) {
     TVM_FFI_ICHECK(inner);
     this->VisitStmt(inner->body);
     return;
+  } else if (op->attr_key == "disable_unroll") {
+    PrintIndent();
+    stream << "#pragma unroll 1\n";
+    this->VisitStmt(op->body);
+    return;
+  } else if (op->attr_key == "pragma_unroll") {
+    PrintIndent();
+    stream << "#pragma unroll\n";
+    this->VisitStmt(op->body);
+    return;
   }
   CodeGenC::VisitStmt_(op);
 }


### PR DESCRIPTION
## Purpose

`CodeGenMACA::VisitStmt_(const tirx::ForNode*)` diverges from `CodeGenCUDA`'s in three ways. None of them looks intentional.

The first is a stale `ICHECK` that no other backend carries.

```cpp
void CodeGenMACA::VisitStmt_(const tirx::ForNode* op) {
  TVM_FFI_ICHECK(is_const_int(op->min, 0));
  ...
```

Only MACA and TRN assert this (`codegen_trn.cc:278` spells it `is_zero(op->min)`), and no CUDA-family backend does. The base implementation MACA delegates to already handles a non-zero `min` (`src/target/source/codegen_c.cc#L1245-L1247`):

```cpp
std::string begin_str = PrintExpr(op->min);
PrimExpr end = is_zero(op->min) ? op->extent : arith::Analyzer()->Simplify(op->min + op->extent);
```

So the assertion only removes a capability that the code underneath it has.

The second is that `disable_unroll` is ignored. A user writing `T.serial(n, unroll=False)` gets `{"disable_unroll": True}` on the loop (`python/tvm/tirx/script/builder/ir.py#L1189-L1192`), which CUDA turns into `#pragma unroll 1`. MACA emitted nothing, so the request not to unroll never reached the compiler.

The third is that `pragma_unroll`, the same annotation family under `unroll=True`, is ignored likewise.

CUDA handles these two annotations in both visitors — on the loop itself (`codegen_cuda.cc:279-287`) and on the enclosing `AttrStmt` (`codegen_cuda.cc:1607-1616`). MACA had neither, so this PR adds both.

## Test Plan

Build with `USE_MACA=ON` and lower the same loop under each annotation, for both targets:

```python
import tvm
from tvm import te, s_tir

def body(target, ann):
    A = te.placeholder((4096,), name="A", dtype="float32")
    B = te.compute((4096,), lambda i: A[i] * 2.0, name="B")
    sch = s_tir.Schedule(te.create_prim_func([A, B]))
    (i,) = sch.get_loops(sch.get_sblock("B"))
    bx, tx, k = sch.split(i, factors=[8, 64, 8])
    sch.bind(bx, "blockIdx.x"); sch.bind(tx, "threadIdx.x")
    if ann:
        sch.annotate(k, ann, True)
    m = tvm.compile(sch.mod, target=target).mod
    src = next(s for s in [m.inspect_source()] + [im.inspect_source() for im in m.imports] if "__global__" in s)
    return [l.strip() for l in src.splitlines() if "pragma" in l or l.strip().startswith("for (")]

for ann in (None, "pragma_unroll", "disable_unroll"):
    for tgt in ("cuda", "maca"):
        print(ann, tgt, body(tgt, ann))
```

## Test Result

MetaX C500, MACA 3.5.3.20, driver 3.8.30.

Before:

```
None            cuda  ['for (int i_2 = 0; i_2 < 8; ++i_2) {']
None            maca  ['for (int i_2 = 0; i_2 < 8; ++i_2) {']
pragma_unroll   cuda  ['#pragma unroll', 'for (int i_2 = 0; i_2 < 8; ++i_2) {']
pragma_unroll   maca  ['for (int i_2 = 0; i_2 < 8; ++i_2) {']
disable_unroll  cuda  ['#pragma unroll 1', 'for (int i_2 = 0; i_2 < 8; ++i_2) {']
disable_unroll  maca  ['for (int i_2 = 0; i_2 < 8; ++i_2) {']
```

After:

```
disable_unroll  cuda  ['#pragma unroll 1', 'for (int i_2 = 0; i_2 < 8; ++i_2) {']
disable_unroll  maca  ['#pragma unroll 1', 'for (int i_2 = 0; i_2 < 8; ++i_2) {']
```

`disable_unroll` now behaves the same on both targets.

One point remains open: `pragma_unroll` still produces no pragma on MACA even with this patch, while the identical `disable_unroll` branch in the same function does fire. So the annotation appears not to reach MACA codegen at all, i.e. something upstream of codegen also differs between the two targets. I did not track that down. The branch is included here because it makes the visitor identical to CUDA's and is harmless — but I am not claiming it as a fix.

The CUDA path is untouched.

