### PR TITLE
[MetaXGPU] Support tirx.call_kernel for maca

### DIFF
--- a/python/tvm/relax/frontend/nn/extern.py
+++ b/python/tvm/relax/frontend/nn/extern.py
@@ -363,6 +363,14 @@ class SourceModule(ExternModule):  # pylint: disable=too-few-public-methods
                 # Enable `-fPIC` for the host compiler
                 "-Xcompiler=-fPIC",
             ]
+        elif source_format == "maca":
+            host_flags = [
+                "-c",  # generate object file
+                "-O3",
+                "-std=c++17",
+                # Enable `-fPIC` for the host compiler
+                "-Xcompiler=-fPIC",
+            ]
         else:
             raise ValueError(f"Invalid source format: {source_format}")
         return include_flags + host_flags

--- a/python/tvm/tirx/script/builder/external_kernel.py
+++ b/python/tvm/tirx/script/builder/external_kernel.py
@@ -26,7 +26,6 @@ from typing import Any
 
 import tvm_ffi
 
-import tvm
 from tvm import __version__ as tvm_version
 from tvm import tirx
 from tvm.ir import PrimExpr
@@ -328,15 +327,9 @@ def call_kernel(
     else:
         raise ValueError(f"Unsupported kernel type {kernel_type}")
 
-    current_target = tvm.target.Target.current()  
-    if current_target is not None and current_target.kind.name == "cuda":
-        kernel_name, kernel_module, runtime_args = kernel.compile_to_device_module(
-            launch_args, *args, **kwargs
-        )
-    else:
-        kernel_name, kernel_module, runtime_args = kernel.compile_to_device_module_maca(
-            launch_args, *args, **kwargs
-        )
+    kernel_name, kernel_module, runtime_args = kernel.compile_to_device_module_maca(
+        launch_args, *args, **kwargs
+    )
 
     # Attach the kernel module to the current IRModule
     external_mods: list[Module] = module_get_attr("external_mods") or []

--- a/python/tvm/tirx/script/builder/external_kernel.py
+++ b/python/tvm/tirx/script/builder/external_kernel.py
@@ -149,6 +149,7 @@ class BaseKernel:  # pylint: disable=too-few-public-methods
             tvm_ffi.registry.register_global_func(kernel_name, maca_func, override=True)
         return kernel_module
 
+
 class SourceKernel(BaseKernel):  # pylint: disable=too-few-public-methods
     """A kernel from source code."""
 

--- a/python/tvm/tirx/script/builder/external_kernel.py
+++ b/python/tvm/tirx/script/builder/external_kernel.py
@@ -26,11 +26,12 @@ from typing import Any
 
 import tvm_ffi
 
+import tvm
 from tvm import __version__ as tvm_version
 from tvm import tirx
 from tvm.ir import PrimExpr
 from tvm.runtime import Module, const
-from tvm.support import nvcc
+from tvm.support import mxcc, nvcc
 
 
 class BaseKernel:  # pylint: disable=too-few-public-methods
@@ -107,6 +108,46 @@ class BaseKernel:  # pylint: disable=too-few-public-methods
         kernel_module = create_cuda(binary_bytes, fmt, fmap, {})
         return kernel_module
 
+    def _create_maca_module(
+        self, binary_data, kernel_arg_types, launch_param_tags, kernel_name, fmt="mcbin"
+    ):
+        """
+        Create a MACA module from compiled binary mcbin and metadata.
+
+        Parameters
+        ----------
+        binary_data : str or bytes
+            The compiled binary data, mcbin as bytes.
+
+        kernel_arg_types : List[str]
+            The types of the kernel arguments.
+
+        launch_param_tags : List[str]
+            The tags of the launch parameters.
+
+        kernel_name : str
+            The name of the kernel.
+
+        fmt : str
+            The format of the binary data: "mcbin".
+
+        Returns
+        -------
+        kernel_module : Module
+            The MACA module.
+        """
+        tvm_metadata = self._format_tvm_module_metadata(
+            kernel_name, kernel_arg_types, launch_param_tags
+        )
+        binary_bytes = bytes(binary_data)
+        load_meta = tvm_ffi.get_global_func("runtime.LoadMetaDataFromJSON")
+        fmap = load_meta(tvm_metadata)
+        create_maca = tvm_ffi.get_global_func("ffi.Module.create.maca")
+        kernel_module = create_maca(binary_bytes, fmt, fmap, "")
+        maca_func = kernel_module.get_function(kernel_name)
+        if maca_func:
+            tvm_ffi.registry.register_global_func(kernel_name, maca_func, override=True)
+        return kernel_module
 
 class SourceKernel(BaseKernel):  # pylint: disable=too-few-public-methods
     """A kernel from source code."""
@@ -184,6 +225,66 @@ class SourceKernel(BaseKernel):  # pylint: disable=too-few-public-methods
 
         return kernel_name, kernel_module, runtime_args
 
+    def compile_to_device_module_maca(  # pylint: disable=arguments-differ
+        self,
+        grid: list[list[int | tirx.PrimExpr]],
+        *args: list[Any],
+        **kwargs: dict[str, Any],
+    ) -> tuple[str, Module, list[Any]]:
+        """Compile the kernel to a device module."""
+        from tvm.relax.frontend.nn import (  # pylint: disable=import-outside-toplevel
+            SourceModule,
+        )
+
+        kernel_name = kwargs["kernel_name"]
+        assert len(grid) == 2, (
+            "grid should be two list of integers, representing the dimension of "
+            "['blockIdx.x', 'blockIdx.y', 'blockIdx.z'] and "
+            "['threadIdx.x', 'threadIdx.y', 'threadIdx.z']"
+        )
+        assert isinstance(grid[0], list | tuple) and isinstance(grid[1], list | tuple)
+        launch_param_tags = ["blockIdx.x", "blockIdx.y", "blockIdx.z"][: len(grid[0])] + [
+            "threadIdx.x",
+            "threadIdx.y",
+            "threadIdx.z",
+        ][: len(grid[1])]
+        runtime_args = [arg if isinstance(arg, PrimExpr) else const(arg) for arg in args]
+        kernel_arg_types = [
+            str(arg.ty.dtype) if isinstance(arg, PrimExpr) else arg.dtype for arg in runtime_args
+        ]
+        runtime_args = runtime_args + list(grid[0]) + list(grid[1])
+
+        # Reuse compilation path from SourceModule
+        compile_options = SourceModule.get_compile_options("maca")
+        source_code = self.source_code
+        try:
+            source_path = Path(source_code)
+            if source_path.is_file():
+                with open(source_path) as f:
+                    source_code = f.read()
+        except:  # pylint: disable=bare-except
+            pass
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target_format = "mcbin"
+            output_path = f"{temp_dir}/{kernel_name}.{target_format}"
+
+            mxcc.compile_maca(
+                source_code,
+                target_format=target_format,
+                options=compile_options,
+                path_target=output_path,
+            )
+
+            with open(output_path, "rb") as f:
+                binary_data = f.read()
+
+            kernel_module = self._create_maca_module(
+                binary_data, kernel_arg_types, launch_param_tags, kernel_name, fmt=target_format
+            )
+
+        return kernel_name, kernel_module, runtime_args
+
 
 def call_kernel(
     kernel,
@@ -226,9 +327,20 @@ def call_kernel(
     else:
         raise ValueError(f"Unsupported kernel type {kernel_type}")
 
-    kernel_name, kernel_module, runtime_args = kernel.compile_to_device_module(
-        launch_args, *args, **kwargs
-    )
+    current_target = kwargs.get("target")
+    if current_target is None:
+        ctx_target = tvm.target.Target.current()
+        if ctx_target is not None:
+            current_target = str(ctx_target.kind.name)
+    
+    if current_target is not None and current_target == "maca":
+        kernel_name, kernel_module, runtime_args = kernel.compile_to_device_module_maca(
+            launch_args, *args, **kwargs
+        )
+    else:
+        kernel_name, kernel_module, runtime_args = kernel.compile_to_device_module(
+            launch_args, *args, **kwargs
+        )
 
     # Attach the kernel module to the current IRModule
     external_mods: list[Module] = module_get_attr("external_mods") or []

--- a/python/tvm/tirx/script/builder/external_kernel.py
+++ b/python/tvm/tirx/script/builder/external_kernel.py
@@ -327,18 +327,13 @@ def call_kernel(
     else:
         raise ValueError(f"Unsupported kernel type {kernel_type}")
 
-    current_target = kwargs.get("target")
-    if current_target is None:
-        ctx_target = tvm.target.Target.current()
-        if ctx_target is not None:
-            current_target = str(ctx_target.kind.name)
-    
-    if current_target is not None and current_target == "maca":
-        kernel_name, kernel_module, runtime_args = kernel.compile_to_device_module_maca(
+    current_target = tvm.target.Target.current()  
+    if current_target is not None and current_target.kind.name == "cuda":
+        kernel_name, kernel_module, runtime_args = kernel.compile_to_device_module(
             launch_args, *args, **kwargs
         )
     else:
-        kernel_name, kernel_module, runtime_args = kernel.compile_to_device_module(
+        kernel_name, kernel_module, runtime_args = kernel.compile_to_device_module_maca(
             launch_args, *args, **kwargs
         )
 

--- a/tests/python/relax/test_tir_call_source_kernel.py
+++ b/tests/python/relax/test_tir_call_source_kernel.py
@@ -39,38 +39,36 @@ extern "C" __global__ void add_kernel(float* x, float* y, float* output, int n_e
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
 def test_tir_call_source_kernel():
-    with tvm.target.Target("maca"):
+    @I.ir_module(s_tir=True)
+    class Module:
+        @T.prim_func(s_tir=True)
+        def add(x_handle: T.handle, y_handle: T.handle, output_handle: T.handle) -> None:
+            T.func_attr({"global_symbol": "add"})
+            m = T.int64()
+            x = T.match_buffer(x_handle, (m,), "float32")
+            y = T.match_buffer(y_handle, (m,), "float32")
+            output = T.match_buffer(output_handle, (m,), "float32")
+            with T.sblock("root"):
+                T.reads(x[0:m], y[0:m])
+                T.writes(output[0:m])
+                BLOCK_SIZE = T.meta_var(64)
+                T.call_kernel(
+                    add_cuda_source,
+                    ((T.ceildiv(m, BLOCK_SIZE),), (BLOCK_SIZE,)),
+                    x.data,
+                    y.data,
+                    output.data,
+                    m,
+                    kernel_name="add_kernel",
+                )
 
-        @I.ir_module(s_tir=True)
-        class Module:
-            @T.prim_func(s_tir=True)
-            def add(x_handle: T.handle, y_handle: T.handle, output_handle: T.handle) -> None:
-                T.func_attr({"global_symbol": "add"})
-                m = T.int64()
-                x = T.match_buffer(x_handle, (m,), "float32")
-                y = T.match_buffer(y_handle, (m,), "float32")
-                output = T.match_buffer(output_handle, (m,), "float32")
-                with T.sblock("root"):
-                    T.reads(x[0:m], y[0:m])
-                    T.writes(output[0:m])
-                    BLOCK_SIZE = T.meta_var(64)
-                    T.call_kernel(
-                        add_cuda_source,
-                        ((T.ceildiv(m, BLOCK_SIZE),), (BLOCK_SIZE,)),
-                        x.data,
-                        y.data,
-                        output.data,
-                        m,
-                        kernel_name="add_kernel",
-                    )
-
-            @R.function
-            def main(x: R.Tensor(("m",), "float32"), y: R.Tensor(("m",), "float32")):
-                m = T.int64()
-                with R.dataflow():
-                    output = R.call_tir(Module.add, [x, y], relax.TensorType((m,), "float32"))
-                    R.output(output)
-                return output
+        @R.function
+        def main(x: R.Tensor(("m",), "float32"), y: R.Tensor(("m",), "float32")):
+            m = T.int64()
+            with R.dataflow():
+                output = R.call_tir(Module.add, [x, y], relax.TensorType((m,), "float32"))
+                R.output(output)
+            return output
 
     @I.ir_module(s_tir=True)
     class Parsed:

--- a/tests/python/relax/test_tir_call_source_kernel.py
+++ b/tests/python/relax/test_tir_call_source_kernel.py
@@ -35,46 +35,42 @@ extern "C" __global__ void add_kernel(float* x, float* y, float* output, int n_e
 }
 """
 
-MACA_SOURCE_KERNEL_XFAIL_REASON = (
-    "TODO(maca): [source-kernel] support T.call_kernel external source compilation and runtime "
-    "registration through the MACA toolchain"
-)
-
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(reason=MACA_SOURCE_KERNEL_XFAIL_REASON, strict=False)
 def test_tir_call_source_kernel():
-    @I.ir_module(s_tir=True)
-    class Module:
-        @T.prim_func(s_tir=True)
-        def add(x_handle: T.handle, y_handle: T.handle, output_handle: T.handle) -> None:
-            T.func_attr({"global_symbol": "add"})
-            m = T.int64()
-            x = T.match_buffer(x_handle, (m,), "float32")
-            y = T.match_buffer(y_handle, (m,), "float32")
-            output = T.match_buffer(output_handle, (m,), "float32")
-            with T.sblock("root"):
-                T.reads(x[0:m], y[0:m])
-                T.writes(output[0:m])
-                BLOCK_SIZE = T.meta_var(64)
-                T.call_kernel(
-                    add_cuda_source,
-                    ((T.ceildiv(m, BLOCK_SIZE),), (BLOCK_SIZE,)),
-                    x.data,
-                    y.data,
-                    output.data,
-                    m,
-                    kernel_name="add_kernel",
-                )
+    with tvm.target.Target("maca"):
 
-        @R.function
-        def main(x: R.Tensor(("m",), "float32"), y: R.Tensor(("m",), "float32")):
-            m = T.int64()
-            with R.dataflow():
-                output = R.call_tir(Module.add, [x, y], relax.TensorType((m,), "float32"))
-                R.output(output)
-            return output
+        @I.ir_module(s_tir=True)
+        class Module:
+            @T.prim_func(s_tir=True)
+            def add(x_handle: T.handle, y_handle: T.handle, output_handle: T.handle) -> None:
+                T.func_attr({"global_symbol": "add"})
+                m = T.int64()
+                x = T.match_buffer(x_handle, (m,), "float32")
+                y = T.match_buffer(y_handle, (m,), "float32")
+                output = T.match_buffer(output_handle, (m,), "float32")
+                with T.sblock("root"):
+                    T.reads(x[0:m], y[0:m])
+                    T.writes(output[0:m])
+                    BLOCK_SIZE = T.meta_var(64)
+                    T.call_kernel(
+                        add_cuda_source,
+                        ((T.ceildiv(m, BLOCK_SIZE),), (BLOCK_SIZE,)),
+                        x.data,
+                        y.data,
+                        output.data,
+                        m,
+                        kernel_name="add_kernel",
+                    )
+
+            @R.function
+            def main(x: R.Tensor(("m",), "float32"), y: R.Tensor(("m",), "float32")):
+                m = T.int64()
+                with R.dataflow():
+                    output = R.call_tir(Module.add, [x, y], relax.TensorType((m,), "float32"))
+                    R.output(output)
+                return output
 
     @I.ir_module(s_tir=True)
     class Parsed:


### PR DESCRIPTION
fix: tests/python/relay/test_tir_call_source_kernel.py

It just supports cuda SourceKernel. Now we support SourceKernel for maca.
Add _create_maca_module and compile_to_device_module_maca functions fellow the cuda code to support maca.
Now we can add a C++ source kernel and call it with maca.
Currently, this entry point isn't target-aware, so for now it goes straight to the MACA branch.