### PR TITLE
[TIRx][MACA] Support tile copy lowering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,7 @@ tvm_file_glob(GLOB CODEGEN_SRCS
   src/backend/maca/codegen/intrin_rule_maca.cc
   src/backend/maca/codegen/maca_fallback_module.cc
   src/backend/maca/codegen/target_kind.cc
+  src/backend/maca/op/*.cc
   src/backend/metal/codegen/*.cc
   src/backend/metal/op/*.cc
   src/backend/opencl/codegen/*.cc

--- a/python/tvm/backend/maca/__init__.py
+++ b/python/tvm/backend/maca/__init__.py
@@ -16,15 +16,35 @@
 # under the License.
 """MACA-owned backend hooks."""
 
+from importlib import import_module
 from pathlib import Path
 
 from tvm_ffi.libinfo import load_lib_ctypes
 
 from tvm.base import _LOADED_LIBS
 
+_LAZY_SUBMODULES = {"op", "operator", "script"}
+
+
+def _detect_target_from_device(dev):
+    from tvm.target import Target  # pylint: disable=import-outside-toplevel
+
+    return Target(
+        {
+            "kind": "maca",
+            "max_shared_memory_per_block": dev.max_shared_memory_per_block,
+            "max_threads_per_block": dev.max_threads_per_block,
+            "thread_warp_size": dev.warp_size,
+            "mcpu": "xcore" + dev.compute_version.replace(".", "") + "0",
+            "mtriple": "mxc-metax-macahca",
+        }
+    )
+
 
 def register_backend():
     """Register MACA-owned Python semantics."""
+    from tvm.target.detect_target import register_device_target_detector
+    from tvm.tirx.script.builder import ir as builder_ir  # pylint: disable=import-outside-toplevel
 
     runtime_dir = Path(_LOADED_LIBS["tvm_runtime"]._name).resolve().parent
     try:
@@ -36,7 +56,42 @@ def register_backend():
         )
     except (OSError, FileNotFoundError, RuntimeError):
         pass
-    return None
+
+    register_device_target_detector("maca", _detect_target_from_device)
+    for name, namespace in script_namespaces().items():
+        builder_ir.register_script_namespace(name, namespace)
+
+    import_module(f"{__name__}.operator.intrinsics")
+    import_module(f"{__name__}.operator.tile_primitive")
 
 
-__all__ = ["register_backend"]
+def script_namespaces(**_):
+    """Return MACA-owned TVMScript namespaces."""
+    from .script import (  # pylint: disable=import-outside-toplevel
+        MACANamespace,
+    )
+
+    return {
+        "maca": MACANamespace(),
+    }
+
+
+def script_namespace(**kwargs):
+    """Return the MACA TVMScript namespace object."""
+    return script_namespaces(**kwargs)["maca"]
+
+
+def __getattr__(name: str):
+    if name in _LAZY_SUBMODULES:
+        return import_module(f"{__name__}.{name}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    "op",
+    "operator",
+    "register_backend",
+    "script",
+    "script_namespace",
+    "script_namespaces",
+]

--- a/python/tvm/backend/maca/op.py
+++ b/python/tvm/backend/maca/op.py
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, too-many-arguments
+"""MACA TIR intrinsic builders."""
+
+from __future__ import annotations
+
+from tvm import tirx
+from tvm.tirx.op import call_intrin
+
+tir = tirx
+
+########################################################
+# MACA native builtins
+########################################################
+
+
+def maca_func_call(func_name, *args, source_code, return_type="void"):
+    """TVM intrinsic to call a MACA function. Source code is provided as a string.
+
+    Parameters
+    ----------
+    func_name: str
+        The name of the MACA function.
+
+    args: PrimExpr
+        The arguments to the MACA function.
+
+    source_code: str
+        The source code of the MACA function.
+
+    return_type: str
+        The return type of the MACA function.
+    """
+    return call_intrin(return_type, "tirx.maca.func_call", func_name, *args, source_code)
+
+
+def maca_thread_fence():
+    """TVM intrinsic to call maca thread fence instruction
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin("", "tirx.maca.thread_fence")
+
+
+def maca_warp_sync():
+    """TVM intrinsic to synchronize threads within the current warp.
+
+    This lowers to a MACA `__syncwarp()` call.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin("", "tirx.maca.warp_sync")
+
+
+def maca_cta_sync():
+    """TVM intrinsic to call MACA syncthreads (block-wide barrier)
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return call_intrin("", "tirx.maca.cta_sync")
+
+
+def maca_copy_bytes(dst, src, num_bytes):
+    """Copy 1, 2, 4, 8, or 16 bytes with one typed load/store pair."""
+    return call_intrin("void", "tirx.maca.copy_bytes", dst, src, num_bytes)
+
+
+def maca_copy_128b(dst, src):
+    """Copy 128 bits from ``src`` to ``dst``."""
+    return maca_copy_bytes(dst, src, 16)
+
+
+def maca_copy_64b(dst, src):
+    """Copy 64 bits from ``src`` to ``dst``."""
+    return maca_copy_bytes(dst, src, 8)
+
+
+def maca_copy_32b(dst, src):
+    """Copy 32 bits from ``src`` to ``dst``."""
+    return maca_copy_bytes(dst, src, 4)
+
+
+def maca_copy_16b(dst, src):
+    """Copy 16 bits from ``src`` to ``dst``."""
+    return maca_copy_bytes(dst, src, 2)
+
+
+def maca_copy_8b(dst, src):
+    """Copy 8 bits from ``src`` to ``dst``."""
+    return maca_copy_bytes(dst, src, 1)

--- a/python/tvm/backend/maca/operator/__init__.py
+++ b/python/tvm/backend/maca/operator/__init__.py
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""MACA backend operator registrations and helpers."""
+
+__all__ = ["intrinsics", "tile_primitive"]

--- a/python/tvm/backend/maca/operator/intrinsics/__init__.py
+++ b/python/tvm/backend/maca/operator/intrinsics/__init__.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=unused-import
+"""MACA HW intrinsic codegens, grouped by feature domain.
+
+- ``sync`` — barriers, fences, mbarrier, cluster.barrier, warp vote, elect, sync helpers.
+
+"""
+
+# Import op modules to register their codegen functions.
+from . import memory, sync
+from .registry import CODEGEN_REGISTRY, get_codegen, register_codegen
+
+__all__ = [
+    "CODEGEN_REGISTRY",
+    "get_codegen",
+    "register_codegen",
+]

--- a/python/tvm/backend/maca/operator/intrinsics/_schema.py
+++ b/python/tvm/backend/maca/operator/intrinsics/_schema.py
@@ -1,0 +1,144 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Thin device-helper registration for TIRx intrinsic codegens.
+
+Exposes one entry point: :func:`device_intrinsic`. Given an op name plus
+``(helper_name, c_signature, body)`` (each a string or a ``(*args) -> str``
+callable), it:
+
+* wraps the body in
+  ``__forceinline__ __device__ <ret> <name><sig> { <body> }``,
+* registers a codegen function under the op name so
+  ``call_intrin("", "tirx.<op_name>", *args)`` resolves to a call to that
+  helper. TVM Op registration is static C++ only.
+
+Args passed to the codegen are split into ``(forward_args, attr_args)``:
+the trailing ``n_attrs`` are attrs (consumed by the ``helper_name`` /
+``c_signature`` / ``body`` callables but **not** forwarded to the helper),
+and the rest are operand args (forwarded). The default ``n_attrs=0`` means
+every arg is forwarded — appropriate for fixed-arity ops with literal
+``c_signature`` and ``helper_name``.
+
+Coerce / validate attrs explicitly inside the callables — there is no
+``Choice`` / ``Bool`` / ``IntAttr`` machinery; just call ``parse_str`` /
+``int`` / ``bool`` on the raw arg as needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from tvm.backend.maca.op import maca_func_call
+from tvm.backend.maca.operator.intrinsics.registry import register_codegen
+
+# C primitive type → TVM dtype string. Used when the caller specifies a
+# non-void ``return_type`` but no explicit ``tvm_return_type`` — the helper
+# knows the TVM-side dtype from the C return type.
+_C_TO_TVM_DTYPE = {
+    "float": "float32",
+    "double": "float64",
+    "uint32_t": "uint32",
+    "int32_t": "int32",
+    "uint64_t": "uint64",
+    "int64_t": "int64",
+    "uint16_t": "uint16",
+    "int16_t": "int16",
+    "unsigned long long": "uint64",
+    "long long": "int64",
+    "unsigned short": "uint16",
+    "bool": "bool",
+    "unsigned int": "uint32",
+    "int": "int32",
+}
+
+
+def device_intrinsic(
+    op_name: str,
+    *,
+    helper_name: str | Callable | None = None,
+    c_signature: str | Callable = "()",
+    body: str | Callable,
+    n_attrs: int = 0,
+    return_type: str | Callable = "void",
+    tvm_return_type: str | Callable | None = None,
+    templated: bool = False,
+    extra_deps: tuple = (),
+) -> None:
+    """Register a MACA device-helper intrinsic.
+
+    Parameters
+    ----------
+    op_name :
+        Registry key — ``call_intrin("", "tirx.<op_name>", ...)`` resolves
+        here. Also used as the default helper name (``tvm_builtin_<op_name>``)
+        when ``helper_name`` is not provided.
+    helper_name :
+        Literal C function name, OR ``(*args) -> str`` to compute it from
+        attr values. Defaults to ``f"tvm_builtin_{op_name}"``.
+    c_signature :
+        Literal C parameter list including outer parens (``"(int x, int y)"``),
+        OR ``(*args) -> str`` to compute it from attr values. Defaults to
+        ``"()"``.
+    body :
+        Literal C body string (already indented), OR ``(*args) -> str``.
+    n_attrs :
+        Number of trailing args that are attrs (consumed by ``helper_name``
+        / ``c_signature`` / ``body`` callables, NOT forwarded to the helper
+        as call arguments). The first ``len(args) - n_attrs`` args are the
+        operand args forwarded to the helper.
+    return_type :
+        C return type. Default ``"void"``. Either a literal string or
+        ``(*args) -> str`` when the helper return type depends on attrs.
+    tvm_return_type :
+        TVM dtype for the call result, when the helper has a non-void
+        return. Either a literal string (``"int32"``) or ``(*args) -> str``.
+        If omitted and ``return_type`` is non-void, it is auto-derived from
+        the ``_C_TO_TVM_DTYPE`` table.
+    templated :
+        Prefix the helper with ``template <typename T>``.
+    extra_deps :
+        Helper-tag list (e.g. ``("get_tmem_addr",)``) forwarded as the second
+        element of the codegen result so the header generator emits the
+        prerequisite snippets.
+    """
+    if helper_name is None:
+        helper_name = f"tvm_builtin_{op_name}"
+    extra_deps = tuple(extra_deps)
+
+    def codegen(*args):
+        forward = args if n_attrs == 0 else args[:-n_attrs]
+        name = helper_name(*args) if callable(helper_name) else helper_name
+        sig = c_signature(*args) if callable(c_signature) else c_signature
+        body_str = body(*args) if callable(body) else body
+        ret_type = return_type(*args) if callable(return_type) else return_type
+        prefix = "template <typename T>\n" if templated else ""
+        source_code = (
+            f"\n{prefix}__forceinline__ __device__ {ret_type} {name}{sig} {{\n{body_str}\n}}\n"
+        )
+        kwargs = {"source_code": source_code}
+        if tvm_return_type is not None:
+            kwargs["return_type"] = (
+                tvm_return_type(*args) if callable(tvm_return_type) else tvm_return_type
+            )
+        elif ret_type != "void":
+            kwargs["return_type"] = _C_TO_TVM_DTYPE.get(ret_type, ret_type)
+        result = maca_func_call(name, *forward, **kwargs)
+        return (result, list(extra_deps)) if extra_deps else result
+
+    codegen.__name__ = f"codegen_{op_name}"
+    register_codegen(op_name)(codegen)

--- a/python/tvm/backend/maca/operator/intrinsics/memory.py
+++ b/python/tvm/backend/maca/operator/intrinsics/memory.py
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""MACA typed memory-copy intrinsic codegens."""
+
+from ._schema import device_intrinsic
+from .registry import CODEGEN_REGISTRY, register_codegen
+
+_TYPE_MAP = {
+    16: "uint4",
+    8: "uint2",
+    4: "unsigned int",
+    2: "unsigned short",
+    1: "unsigned char",
+}
+
+for _num_bytes, _cpp_type in _TYPE_MAP.items():
+    device_intrinsic(
+        f"_maca_copy_bytes_{_num_bytes}_impl",
+        helper_name=f"tvm_builtin_copy_{_num_bytes * 8}b",
+        c_signature="(void* dst_ptr, const void* src_ptr)",
+        body=(
+            f"    const {_cpp_type}* src_ = reinterpret_cast<const {_cpp_type}*>(src_ptr);\n"
+            f"    {_cpp_type}* dst_ = reinterpret_cast<{_cpp_type}*>(dst_ptr);\n"
+            "    *dst_ = *src_;"
+        ),
+    )
+del _num_bytes, _cpp_type
+
+
+@register_codegen("maca_copy_bytes")
+def codegen_maca_copy_bytes(dst, src, num_bytes):
+    """Dispatch ``tirx.maca.copy_bytes`` to a width-specific helper."""
+    num_bytes_int = int(num_bytes)
+    if num_bytes_int not in _TYPE_MAP:
+        raise ValueError(
+            f"Unsupported maca_copy_bytes num_bytes {num_bytes_int}, "
+            f"expected one of {sorted(_TYPE_MAP)}"
+        )
+    result = CODEGEN_REGISTRY[f"tirx._maca_copy_bytes_{num_bytes_int}_impl"]([dst, src])
+    return result[0] if isinstance(result, tuple) else result

--- a/python/tvm/backend/maca/operator/intrinsics/registry.py
+++ b/python/tvm/backend/maca/operator/intrinsics/registry.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Codegen registry for MACA HW ops.
+
+User-facing Python wrappers are hand-written in :mod:`tvm.tirx.op` so that
+editors / static analyzers (Cursor, Pyright) can see their signatures. This
+module only handles the backend codegen side.
+"""
+
+import functools
+
+import tvm_ffi
+
+CODEGEN_REGISTRY = {}
+
+
+def _canonical_device_intrin_name(op_name: str) -> str:
+    if not op_name.startswith("tirx."):
+        return op_name
+    basename = op_name[len("tirx.") :]
+    if "." in basename:
+        return op_name
+    for prefix, namespace in (("maca_", "maca"),):
+        if basename.startswith(prefix):
+            return f"tirx.{namespace}.{basename[len(prefix) :]}"
+    return op_name
+
+
+@tvm_ffi.register_global_func("tirx.intrinsics.maca.get_codegen")
+def get_codegen(op):
+    """get the codegen function for a given op"""
+    return CODEGEN_REGISTRY.get(op, None)
+
+
+def register_codegen(op, backend="maca"):
+    """Register a codegen function for a given op.
+
+    The codegen function should return a ``maca_func_call`` statement, and
+    optionally a list of tags that the codegen function needs.
+    """
+
+    def decorator(func):
+        full_op_name = "tirx." + op
+        canonical_op_name = _canonical_device_intrin_name(full_op_name)
+        op_names = {full_op_name, canonical_op_name}
+
+        @functools.wraps(func)
+        def wrapper(arg_list):
+            res = func(*arg_list)  # pylint: disable=not-callable
+            if isinstance(res, tuple):
+                return res[0], res[1]
+            return res, list()
+
+        for op_name in op_names:
+            CODEGEN_REGISTRY[op_name] = wrapper
+        return wrapper
+
+    return decorator

--- a/python/tvm/backend/maca/operator/intrinsics/sync.py
+++ b/python/tvm/backend/maca/operator/intrinsics/sync.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name
+"""Synchronization primitives.
+
+MACA-side helpers:
+* ``__threadfence`` / ``__syncwarp`` / ``__syncthreads`` / ``__syncthreads_and|or``
+* cooperative-groups grid sync
+* cluster sync (open-coded ``barrier.cluster.arrive/wait`` pair)
+* warpgroup sync (``bar.sync``)
+"""
+
+from ._schema import device_intrinsic
+
+# =============================================================================
+# MACA-side sync helpers (zero-arg void unless noted).
+# =============================================================================
+device_intrinsic("maca_thread_fence", body="    __threadfence();")
+device_intrinsic("maca_warp_sync", body="    __syncwarp();")
+device_intrinsic("maca_cta_sync", body="    __syncthreads();")

--- a/python/tvm/backend/maca/operator/intrinsics/utils.py
+++ b/python/tvm/backend/maca/operator/intrinsics/utils.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Common utility functions for MACA op codegen."""
+
+
+def parse_str(arg) -> str:
+    """Parse TIR StringImm or Python str to a plain str.
+
+    TIR StringImm values stringify to quoted strings, e.g., ``'"float16"'``;
+    Python strs do not. Idempotent — passing an already-parsed str returns it
+    unchanged, so dispatchers that parse once before forwarding to inner
+    codegens won't double-strip the value.
+    """
+    s = str(arg)
+    if len(s) >= 2 and s[0] == '"' and s[-1] == '"':
+        return s[1:-1]
+    return s
+
+
+def is_power_of_two(n: int) -> bool:
+    """Check if n is a power of two."""
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def validate_cta_group(cta_group, context: str = "") -> int:
+    """Validate that cta_group is 1 or 2 and return it as int.
+
+    Args:
+        cta_group: The cta_group value (can be int or TIR IntImm)
+        context: Optional context string for error message (e.g., "allocating Tensor Memory")
+
+    Returns:
+        The validated cta_group as int
+
+    Raises:
+        ValueError: If cta_group is not 1 or 2
+    """
+    cta_group = int(cta_group)
+    if cta_group not in [1, 2]:
+        ctx = f" involved in {context}" if context else ""
+        raise ValueError(
+            f"The number of cta_group{ctx} is incorrect, expected 1 or 2, got {cta_group}"
+        )
+    return cta_group
+
+
+def validate_power_of_two_range(value, min_val: int, max_val: int, name: str) -> int:
+    """Validate that value is within range and is a power of two.
+
+    Args:
+        value: The value to validate
+        min_val: Minimum allowed value (inclusive)
+        max_val: Maximum allowed value (inclusive)
+        name: Name of the parameter for error messages
+
+    Returns:
+        The validated value as int
+
+    Raises:
+        ValueError: If value is out of range or not a power of two
+    """
+    value = int(value)
+    if not (min_val <= value <= max_val and is_power_of_two(value)):
+        raise ValueError(
+            f"The {name} is invalid, expect a value within range [{min_val}, {max_val}] "
+            f"and be a power of 2, got {value}"
+        )
+    return value

--- a/python/tvm/backend/maca/operator/tile_primitive/__init__.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from .copy import *

--- a/python/tvm/backend/maca/operator/tile_primitive/common.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/common.py
@@ -1,0 +1,249 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Common utilities for MACA operator scheduling (basic helpers and copy ops)."""
+
+import functools
+import operator
+from enum import Enum
+
+from tvm.arith.analyzer import Analyzer
+from tvm.runtime import DataType
+from tvm.script import tirx as T
+from tvm.tirx import Buffer, BufferRegion, PrimFunc
+from tvm.tirx.operator.tile_primitive import DispatchContext, fail
+from tvm.tirx.stmt import TilePrimitiveCall
+
+
+def next_power_of_2(x: int) -> int:
+    """Return the smallest power of 2 greater than or equal to x."""
+    if x <= 1:
+        return 1
+    return 1 << (x - 1).bit_length()
+
+
+def get_st_extent(buffer_region: BufferRegion):
+    """Get the start and extent of a buffer region."""
+    region = buffer_region.region
+    return [r.min for r in region], [r.extent for r in region]
+
+
+def get_indices(nth, start, extent):
+    """Convert a fused index into multi-dimensional indices."""
+    assert len(start) == len(extent)
+    if len(start) == 1:
+        return [start[0] + nth]
+    relative = []
+    for e in reversed(extent):
+        relative.append(nth % e)
+        nth //= e
+    return [r + s for r, s in zip(reversed(relative), start)]
+
+
+class CopyInstType(Enum):
+    """Enumeration of instruction types for memory operations."""
+
+    NORMAL = 0
+    CP_ASYNC = 1
+
+
+def validate_copy_op(
+    op_call: TilePrimitiveCall,
+    sctx: DispatchContext,  # pylint: disable=unused-argument
+) -> bool:
+    """Sanity check for copy op"""
+    dst_buffer_region, src_buffer_region = op_call.args[:2]
+    src: Buffer = src_buffer_region.buffer
+    dst: Buffer = dst_buffer_region.buffer
+    if not (src.layout and dst.layout and src.dtype == dst.dtype):
+        return False
+    # Extract regions and validate dimensions
+    analyzer = Analyzer()
+    src_region, dst_region = src_buffer_region.region, dst_buffer_region.region
+    # Extract extents and validate non-unit dimensions match
+    src_extent_ = [r.extent for r in src_region if r.extent != 1]
+    dst_extent_ = [r.extent for r in dst_region if r.extent != 1]
+    if len(src_extent_) != len(dst_extent_) or not all(
+        analyzer.can_prove_equal(s, d) for s, d in zip(src_extent_, dst_extent_)
+    ):
+        return False
+    return True
+
+
+def get_vec_len(
+    dst_buffer_region: BufferRegion,
+    src_buffer_region: BufferRegion,
+    vec_candidates: list[int],
+    thread_cnt=1,
+) -> int | None:
+    """Get the vector length for the copy operation."""
+
+    dst: Buffer = dst_buffer_region.buffer
+    src: Buffer = src_buffer_region.buffer
+    # layout=None (flat local buffer) is treated as trivial for vectorization purposes
+    if not (
+        (dst.layout is None or dst.layout.is_trivial())
+        and (src.layout is None or src.layout.is_trivial())
+    ):
+        return None
+
+    # Extract regions and validate dimensions
+    analyzer = Analyzer()
+    src_st, src_extent = get_st_extent(src_buffer_region)
+    dst_st, dst_extent = get_st_extent(dst_buffer_region)
+
+    # Thread and vectorization setup
+    DataType(src.dtype).bits  # in bits
+    n_elements = functools.reduce(operator.mul, src_extent, 1)
+    if n_elements % thread_cnt != 0:
+        return None
+
+    # Find valid vector length
+    for vec_len in vec_candidates:
+        if vec_len > 0 and all(
+            analyzer.can_prove_equal(x % vec_len, 0)
+            for x in [
+                src_st[-1],
+                dst_st[-1],
+                src.shape[-1] if len(src.shape) > 1 else 0,
+                dst.shape[-1] if len(dst.shape) > 1 else 0,
+                src_extent[-1],
+                dst_extent[-1],
+                n_elements // thread_cnt,
+            ]
+        ):
+            return vec_len
+    else:
+        return None
+
+
+def copy_vec_load_impl(
+    op_call: TilePrimitiveCall, sctx: DispatchContext, inst_type: CopyInstType
+) -> PrimFunc | None:
+    """Schedule copy operation between global and local/shared memory on MACA across a CTA/thread.
+    The implementation tries to vectorize the copy operation and parallelize over
+    threads in a CTA/using a single thread.
+    """
+    dst_buffer_region, src_buffer_region = op_call.args[:2]
+    src: Buffer = src_buffer_region.buffer
+    dst: Buffer = dst_buffer_region.buffer
+    if not (
+        (src.scope() == "global" and dst.scope().startswith("shared"))
+        or (src.scope().startswith("shared") and dst.scope() == "global")
+        or (src.scope() == "global" and dst.scope() == "local")
+        or (src.scope() == "local" and dst.scope() == "global")
+        or (src.scope().startswith("shared") and dst.scope() == "local")
+        or (dst.scope().startswith("shared") and src.scope() == "local")
+    ):
+        fail(f"unsupported memory scopes src={src.scope()} dst={dst.scope()}")
+
+    # Thread and vectorization setup
+    if sctx.is_cta:
+        tx = sctx.launch_params["threadIdx.x"].dom.extent
+        assert "threadIdx.y" not in sctx.launch_params and "threadIdx.z" not in sctx.launch_params
+    elif sctx.is_thread:
+        tx = 1
+    else:
+        fail(f"unsupported exec_scope {sctx.scope_kind}")
+
+    elem_size = DataType(src.dtype).bits  # in bits
+    vec_len = op_call.config.get("vec_len", None)
+    if vec_len is None:
+        vec_len = get_vec_len(
+            dst_buffer_region,
+            src_buffer_region,
+            [128 // elem_size, 64 // elem_size, 32 // elem_size, 1],
+            thread_cnt=tx,
+        )
+    if vec_len is None:
+        fail("no valid vector length; check alignment/extents/thread-count")
+
+    # cp-size (the size of data in bytes) can only be 4, 8 and 16 for cp.async
+    if inst_type == CopyInstType.CP_ASYNC:
+        cp_size = vec_len * elem_size // 8  # in bytes
+        if cp_size not in [4, 8, 16]:
+            fail("invalid cp.async cp_size; expected 4, 8 or 16 bytes")
+
+    src_st, src_extent = get_st_extent(src_buffer_region)
+    dst_st, dst_extent = get_st_extent(dst_buffer_region)
+    n_elements = functools.reduce(operator.mul, src_extent, 1)
+
+    if sctx.is_cta:
+        # fmt: off
+        @T.prim_func
+        def impl():
+            """Implement copy operation with vectorized loads/stores."""
+            for s in T.serial(0, n_elements // (tx * vec_len)):
+                for tid_x in T.thread_binding(tx, "threadIdx.x"):
+                    if inst_type == CopyInstType.NORMAL:
+                        for vec in T.vectorized(vec_len):
+                            fused = T.meta_var((s * tx + tid_x) * vec_len + vec)
+                            dst_indices = T.meta_var(get_indices(fused, dst_st, dst_extent))
+                            src_indices = T.meta_var(get_indices(fused, src_st, src_extent))
+                            dst[tuple(dst_indices)] = src[tuple(src_indices)]
+                    elif inst_type == CopyInstType.CP_ASYNC:
+                        fused = T.meta_var((s * tx + tid_x) * vec_len)
+                        dst_indices = T.meta_var(get_indices(fused, dst_st, dst_extent))
+                        src_indices = T.meta_var(get_indices(fused, src_st, src_extent))
+                        T.evaluate(T.ptx.cp_async(dst.ptr_to(dst_indices), src.ptr_to(src_indices), cp_size))  # noqa: E501
+            if dst.scope().startswith("shared") and inst_type == CopyInstType.NORMAL:
+                T.tvm_storage_sync("shared")
+        # fmt: on
+    elif sctx.is_thread:
+        # fmt: off
+        @T.prim_func(check_well_formed=False)
+        def impl():
+            for s in T.serial(0, n_elements // (vec_len)):
+                if inst_type == CopyInstType.NORMAL:
+                    for vec in T.vectorized(vec_len):
+                        fused = T.meta_var(s * vec_len + vec)
+                        dst_indices = T.meta_var(get_indices(fused, dst_st, dst_extent))
+                        src_indices = T.meta_var(get_indices(fused, src_st, src_extent))
+                        dst[tuple(dst_indices)] = src[tuple(src_indices)]
+                elif inst_type == CopyInstType.CP_ASYNC:
+                    fused = T.meta_var(s * vec_len)
+                    dst_indices = T.meta_var(get_indices(fused, dst_st, dst_extent))
+                    src_indices = T.meta_var(get_indices(fused, src_st, src_extent))
+                    T.evaluate(T.ptx.cp_async(dst.ptr_to(dst_indices), src.ptr_to(src_indices), cp_size))  # noqa: E501
+        # fmt: on
+    else:
+        fail(f"unsupported exec_scope {sctx.scope_kind}")
+    return impl
+
+
+def match_scope(scope: str | None, pattern: str) -> bool:
+    """Glob-lite scope matching: 'shared*' => prefix match; otherwise exact.
+
+    Returns True when scope is None (meaning "any scope is fine").
+    """
+    if scope is None:
+        return True
+    if pattern.endswith("*"):
+        return scope.startswith(pattern[:-1])
+    return scope == pattern
+
+
+def get_thread_cnt(sctx: DispatchContext) -> int | None:
+    """Get thread count for the current execution scope."""
+    scope_name = sctx.scope_kind
+    if scope_name == "cta":
+        return sctx.launch_params["threadIdx.x"].dom.extent
+    if scope_name == "warp":
+        return 64
+    if scope_name == "thread":
+        return 1
+    return None

--- a/python/tvm/backend/maca/operator/tile_primitive/copy/__init__.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/copy/__init__.py
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from .fallback import *
+from .reg import *
+from .utils import (
+    _is_valid_copy,
+    _scope_allowed,
+    _single_thread_exec,
+)

--- a/python/tvm/backend/maca/operator/tile_primitive/copy/_common.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/copy/_common.py
@@ -1,0 +1,539 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Shared partition / layout algorithm for synthesized-partition copy
+dispatches (currently ``gmem_smem`` and ``ldgsts``).
+
+``gmem_smem`` (sync ``Tx.copy`` global ↔ shared) and ``ldgsts`` (async
+``Tx.copy_async`` global → shared via cp.async / SASS LDGSTS) share the
+same algorithm to pick a vec-isolating + thread-distributing layout for
+``G ↔ S`` copies. Only emit-time details differ (which copy instruction
+to call, allowed vec widths). All the layout/partition logic lives here.
+"""
+
+from tvm import arith
+from tvm.tirx.layout import ComposeLayout, Iter, S, SwizzleLayout, TileLayout
+from tvm.tirx.operator.tile_primitive.registry import DispatchContext
+
+
+def _alignment_ok(vec_len: int, terms) -> bool:
+    """Every term must be a multiple of ``vec_len``. Constants checked
+    directly; PrimExpr / symbolic terms checked via ``arith.Analyzer``.
+
+    ``vec_len=1`` always passes (the scalar fallback). When a symbolic
+    term can't be proved divisible, returns ``False`` conservatively —
+    the candidate loop will then try a smaller ``vec_len``.
+    """
+    if vec_len <= 1:
+        return True
+    analyzer = arith.Analyzer()
+    for t in terms:
+        if isinstance(t, int):
+            if t % vec_len != 0:
+                return False
+        else:
+            if not analyzer.can_prove_equal(t % vec_len, 0):
+                return False
+    return True
+
+
+# scope_kind → name of the scope_id that decomposes the scope into per-thread.
+_TID_AXIS_FOR_SCOPE = {
+    "warp": "laneid",
+    "cta": "tx",
+}
+
+
+def _thread_cnt(sctx: DispatchContext) -> int:
+    """Total threads active in the current scope = ∏ intra-axis extents.
+
+    For thread scope ``sctx.intra`` is empty → returns 1.
+    """
+    n = 1
+    for ext, _off in sctx.intra.values():
+        n *= int(ext)
+    return n
+
+
+# -----------------------------------------------------------------------------
+# Layout primitives
+# -----------------------------------------------------------------------------
+
+
+def _contig_group(iters: list) -> list[int]:
+    """Indices (in iters) of the maximal physical-contiguous chain starting
+    at the stride=1 iter, ordered stride-ascending.
+
+    Returns [] if no stride=1 iter exists.
+    """
+    one_idx = next(
+        (i for i, it in enumerate(iters) if int(it.stride) == 1),
+        None,
+    )
+    if one_idx is None:
+        return []
+    chain = [one_idx]
+    acc = int(iters[one_idx].extent)
+    used = {one_idx}
+    while True:
+        nxt = next(
+            (i for i, it in enumerate(iters) if i not in used and int(it.stride) == acc),
+            None,
+        )
+        if nxt is None:
+            break
+        chain.append(nxt)
+        acc *= int(iters[nxt].extent)
+        used.add(nxt)
+    return chain
+
+
+def _try_split_vec(iters: list, vec_len: int):
+    """Try to walk ``vec_len`` consecutive elements along the contig chain.
+
+    Returns ``(new_iters, selected_positions)`` on success, ``None`` on
+    failure. ``new_iters`` may contain a freshly-split iter (replacing one
+    entry with its "outer" half, with the "inner" half appended at the end);
+    ``selected_positions`` are positions in ``new_iters`` that together
+    cover the ``vec_len`` contig elements.
+    """
+    chain = _contig_group(iters)
+    if not chain:
+        return None
+    rem = vec_len
+    new_iters = list(iters)
+    selected: list[int] = []
+    for orig_idx in chain:
+        if rem == 0:
+            break
+        it = new_iters[orig_idx]
+        ext = int(it.extent)
+        if ext <= rem:
+            if rem % ext != 0:
+                return None
+            selected.append(orig_idx)
+            rem //= ext
+        else:
+            if ext % rem != 0:
+                return None
+            stride = int(it.stride)
+            outer = Iter(ext // rem, stride * rem, it.axis)
+            inner = Iter(rem, stride, it.axis)
+            new_iters[orig_idx] = outer
+            new_iters.append(inner)
+            selected.append(len(new_iters) - 1)
+            rem = 0
+            break
+    if rem != 0:
+        return None
+    return new_iters, selected
+
+
+def _isolated_shape(iters: list, selected: list[int]) -> tuple[list[int], list[tuple[int, int]]]:
+    """Build the isolated shape: each selected iter is its own segment;
+    adjacent unselected iters are merged into a single segment.
+
+    Returns ``(shape, segments)`` where ``segments[i] = (start, end)`` is
+    the half-open range in ``iters`` covered by shape entry ``i``.
+    """
+    sel_set = set(selected)
+    shape: list[int] = []
+    segments: list[tuple[int, int]] = []
+    cur_start = None
+    cur_ext = 1
+    for i, it in enumerate(iters):
+        if i in sel_set:
+            if cur_start is not None:
+                shape.append(cur_ext)
+                segments.append((cur_start, i))
+                cur_start = None
+                cur_ext = 1
+            shape.append(int(it.extent))
+            segments.append((i, i + 1))
+        else:
+            if cur_start is None:
+                cur_start = i
+            cur_ext *= int(it.extent)
+    if cur_start is not None:
+        shape.append(cur_ext)
+        segments.append((cur_start, len(iters)))
+    return shape, segments
+
+
+def _vec_perm(iters: list, selected: list[int]) -> list[int]:
+    """Reorder ``iters`` into ``[outer, vec]``, both ordered by stride
+    descending so the stride=1 iter ends up at the very last position."""
+    sel_set = set(selected)
+    unsel_sorted = sorted(
+        (i for i in range(len(iters)) if i not in sel_set),
+        key=lambda i: -int(iters[i].stride),
+    )
+    sel_sorted = sorted(selected, key=lambda i: -int(iters[i].stride))
+    return list(unsel_sorted) + sel_sorted
+
+
+def _try_split_thread(iters: list, vec_selected: list[int], thread_cnt: int):
+    """After ``_try_split_vec``, carve ``thread_cnt`` from the OUTER tail
+    (smallest-stride outer iter, then towards bigger stride if needed).
+
+    Unlike vec split, this doesn't require physical contiguity — T
+    consecutive fused indices map to per-thread offsets via the layout's
+    stride (which may be > 1).
+
+    Returns ``(new_iters, thread_selected_positions)`` on success, ``None``
+    on failure (outer doesn't divide T cleanly, or no outer iters left).
+    """
+    if thread_cnt == 1:
+        return list(iters), []
+    vec_set = set(vec_selected)
+    outer = [i for i in range(len(iters)) if i not in vec_set]
+    if not outer:
+        return None
+    outer_by_stride_desc = sorted(outer, key=lambda i: -int(iters[i].stride))
+    rem = thread_cnt
+    new_iters = list(iters)
+    thread_selected: list[int] = []
+    for orig_idx in reversed(outer_by_stride_desc):
+        if rem == 0:
+            break
+        it = new_iters[orig_idx]
+        ext = int(it.extent)
+        if ext <= rem:
+            if rem % ext != 0:
+                return None
+            thread_selected.append(orig_idx)
+            rem //= ext
+        else:
+            if ext % rem != 0:
+                return None
+            stride = int(it.stride)
+            new_iters[orig_idx] = Iter(ext // rem, stride * rem, it.axis)
+            new_iters.append(Iter(rem, stride, it.axis))
+            thread_selected.append(len(new_iters) - 1)
+            rem = 0
+            break
+    if rem != 0:
+        return None
+    return new_iters, thread_selected
+
+
+def _three_segment_perm(iters: list, t_selected: list[int], vec_selected: list[int]) -> list[int]:
+    """Reorder ``iters`` into ``[outer, T, vec]`` segments. Within each
+    segment, stride descending so stride=1 sits at the very end."""
+    t_set = set(t_selected)
+    vec_set = set(vec_selected)
+    outer = sorted(
+        (i for i in range(len(iters)) if i not in t_set and i not in vec_set),
+        key=lambda i: -int(iters[i].stride),
+    )
+    t_sorted = sorted(t_selected, key=lambda i: -int(iters[i].stride))
+    vec_sorted = sorted(vec_selected, key=lambda i: -int(iters[i].stride))
+    return list(outer) + t_sorted + vec_sorted
+
+
+def _shape_perm_for_isolated(
+    shape_segments: list[tuple[int, int]], iter_perm: list[int]
+) -> list[int]:
+    """Given segments (one per shape entry, each = (start, end) in
+    pre-perm iter positions) and the iter permutation, compute the
+    corresponding shape permutation."""
+    seg_of = [0] * sum(end - start for start, end in shape_segments)
+    for seg_idx, (start, end) in enumerate(shape_segments):
+        for k in range(start, end):
+            seg_of[k] = seg_idx
+    seen: set[int] = set()
+    perm: list[int] = []
+    for orig_idx in iter_perm:
+        seg_idx = seg_of[orig_idx]
+        if seg_idx not in seen:
+            seen.add(seg_idx)
+            perm.append(seg_idx)
+    return perm
+
+
+def _verify_s_tail_contig(s_p: TileLayout, vec_len: int) -> bool:
+    """Check the last iters of ``s_p`` form a stride=1 contig chain whose
+    extent product equals ``vec_len``."""
+    iters = list(s_p.shard)
+    if not iters:
+        return vec_len == 1
+    last = iters[-1]
+    if int(last.stride) != 1:
+        return False
+    acc = int(last.extent)
+    if acc == vec_len:
+        return True
+    for k in range(len(iters) - 2, -1, -1):
+        it = iters[k]
+        if int(it.stride) != acc:
+            break
+        acc *= int(it.extent)
+        if acc == vec_len:
+            return True
+        if acc > vec_len:
+            return False
+    return acc >= vec_len and acc % vec_len == 0
+
+
+_VEC_BITS_CANDIDATES = (128, 64, 32, 16, 8)
+
+
+def _vec_len_candidates(elem_bits: int, allowed_bits: tuple | None = None) -> list[int]:
+    """Vec-length candidates (in elements) for the given element width.
+
+    ``allowed_bits`` optionally filters the per-instruction allowed widths
+    (e.g. cp.async only accepts {128, 64, 32} bits = 16/8/4 bytes).
+    Defaults to ``_VEC_BITS_CANDIDATES`` if not specified.
+    """
+    bits_tuple = allowed_bits if allowed_bits is not None else _VEC_BITS_CANDIDATES
+    out: list[int] = []
+    for vb in bits_tuple:
+        if vb < elem_bits or vb % elem_bits != 0:
+            continue
+        n = vb // elem_bits
+        if n not in out:
+            out.append(n)
+    if 1 not in out and allowed_bits is None:
+        # Scalar fallback is only added for the unrestricted candidate set;
+        # an instruction-specific list (cp.async etc.) keeps its strictness.
+        out.append(1)
+    return out
+
+
+def _extract_tile(layout, region):
+    """Strip swizzle so we can perm/group as a TileLayout."""
+    if isinstance(layout, ComposeLayout):
+        return layout.tile_layout
+    if isinstance(layout, SwizzleLayout):
+        extents = [int(end - start) for (start, end) in region]
+        return TileLayout(S[tuple(extents)])
+    return layout
+
+
+def _sort_by_stride_desc(layout: TileLayout) -> TileLayout:
+    """Reorder shard so list order = traversal order (outer first, stride=1
+    last). Required before canonicalize() can fuse non-adjacent-but-contig
+    iters."""
+    iters = list(layout.shard)
+    perm = sorted(range(len(iters)), key=lambda i: -int(iters[i].stride))
+    if perm == list(range(len(iters))):
+        return layout
+    return layout.permute_dims(perm)
+
+
+def _carve_tail(iters: list, chunk: int):
+    """Carve ``chunk`` elements off the tail. Walk back across multiple
+    iters as needed; at most one iter is split.
+
+    Per iter (from last to first), let ``ext`` = iter extent and ``rem``
+    = remaining chunk to fill:
+
+    * ``ext == rem``: eat this iter whole, done.
+    * ``ext < rem``: must divide ``rem``; eat whole, ``rem //= ext``.
+    * ``ext > rem``: must divide ``ext``; split into
+      ``(ext/rem, stride*rem) + (rem, stride)``, take the inner. Done.
+
+    Returns the new iter list on success, ``None`` on failure.
+    """
+    if not iters or chunk <= 0:
+        return None
+    rem = chunk
+    work = list(iters)
+    for idx in range(len(work) - 1, -1, -1):
+        it = work[idx]
+        ext = int(it.extent)
+        if ext == rem:
+            return work
+        if ext < rem:
+            if rem % ext != 0:
+                return None
+            rem //= ext
+            continue
+        if ext % rem != 0:
+            return None
+        stride = int(it.stride)
+        work[idx] = Iter(ext // rem, stride * rem, it.axis)
+        work.insert(idx + 1, Iter(rem, stride, it.axis))
+        return work
+    return None
+
+
+def align_layouts_gs(
+    g_layout,
+    g_shape,
+    g_region,
+    s_layout,
+    s_shape,
+    s_region,
+    elem_bits,
+    thread_cnt: int,
+    vec_bits_candidates: tuple | None = None,
+    debug: bool = False,
+):
+    """Align G and S layouts for a synthesized G↔S copy.
+
+    Algorithm:
+      1. Sort G iters by stride desc + canonicalize (fuses anything physically
+         contig). Same for S.
+      2. Group S by G's iter shape (per-iter shape list) + permute_by_groups
+         with identity so S's groups line up with G's iters.
+      3. Carve ``vec_len`` off G's tail (a single iter split if needed).
+      4. Carve ``T = thread_cnt`` off the iter before vec (multi-iter walk,
+         single split).
+      5. Re-group S (already permuted) by the new finer per-iter shape. No
+         further permute needed because steps 3-4 only refine the tail.
+      6. Verify S's tail (vec segment) is physically contig.
+
+    ``vec_bits_candidates`` optionally restricts the per-instruction allowed
+    widths (e.g. cp.async only accepts {128, 64, 32} bits). When ``None``
+    (default), uses the full {128, 64, 32, 16, 8} set plus a scalar (1)
+    fallback.
+
+    Returns ``(g_p, s_p, vec_len)``. ``g_p.shard`` ends as
+    ``[outer iters..., T iter, vec iter]``; ``s_p.shard`` has the same iter
+    count and matching iter-by-iter extents.
+    """
+    g = g_layout.slice(list(g_shape), g_region)
+    s = s_layout.slice(list(s_shape), s_region)
+    # Detect a SwizzleLayout on the S side BEFORE _extract_tile strips it.
+    # vec_len must fit inside one swizzle chunk (C = 2^per_element elements);
+    # otherwise the vec ld/st crosses a swizzle XOR boundary and hits the
+    # wrong physical bytes mid-vec.
+    s_swizzle_chunk_elems = None
+    if isinstance(s_layout, ComposeLayout):
+        s_swizzle_chunk_elems = 1 << int(s_layout.swizzle.per_element)
+    elif isinstance(s_layout, SwizzleLayout):
+        s_swizzle_chunk_elems = 1 << int(s_layout.per_element)
+    g = _extract_tile(g, g_region)
+    s = _extract_tile(s, s_region)
+
+    # Only G drives the canonical form. S's iter order is derived from G's
+    # pre-sort iter extents (used as the grouping shape) and then permuted
+    # by G's stride-desc permutation. Independently sorting/canonicalizing
+    # S would fuse iters whose strides happen to chain into one contiguous
+    # range — that loses the layout's logical `(i, j) → addr` mapping for
+    # layout-permuting copies (e.g. row-major GMEM → K-tiled SMEM, where
+    # both layouts cover the same byte range but with different coord maps).
+    g_pre_sort_extents = [int(it.extent) for it in g.shard]
+    g_perm = sorted(range(len(g.shard)), key=lambda i: -int(g.shard[i].stride))
+    try:
+        s_grp1, seps1 = s.group(g_pre_sort_extents)
+    except Exception as e:
+        if debug:
+            print(f"    Step-2 S.group({g_pre_sort_extents}) failed: {e}")
+        return _sort_by_stride_desc(g).canonicalize(), s, 1
+    # S iters keep their original strides; only the *group order* is
+    # rearranged to follow G's sorted iter order. Canonicalize after the
+    # permute is safe — it only fuses iters whose strides genuinely chain
+    # in the post-permute order, which preserves the logical structure.
+    s_aligned = s_grp1.permute_by_groups(list(seps1), g_perm).canonicalize()
+    g = _sort_by_stride_desc(g).canonicalize()
+    if debug:
+        print(f"    g (sort+canon): shard={[(int(it.extent), int(it.stride)) for it in g.shard]}")
+        print(
+            f"    s (grouped+permuted by G shape {g_pre_sort_extents}): shard="
+            f"{[(int(it.extent), int(it.stride)) for it in s_aligned.shard]}"
+        )
+        print(f"    thread_cnt: {thread_cnt}")
+
+    dummy_axis = g.shard[-1].axis if g.shard else None
+
+    for vec_len in _vec_len_candidates(elem_bits, vec_bits_candidates):
+        if vec_len == 1:
+            g_after_vec = [*list(g.shard), Iter(1, 1, dummy_axis)]
+        else:
+            # Swizzle chunk-size cap: vec must fit in one swizzle chunk.
+            if s_swizzle_chunk_elems is not None and vec_len > s_swizzle_chunk_elems:
+                if debug:
+                    print(
+                        f"    vec_len={vec_len}: exceeds swizzle chunk "
+                        f"({s_swizzle_chunk_elems} elements)"
+                    )
+                continue
+            g_after_vec = _carve_tail(list(g.shard), vec_len)
+            if g_after_vec is None:
+                if debug:
+                    print(f"    vec_len={vec_len}: G vec carve failed")
+                continue
+        outer_for_t = g_after_vec[:-1]
+        outer_after_t = _carve_tail(outer_for_t, thread_cnt) if thread_cnt > 1 else outer_for_t
+        if outer_after_t is None:
+            if debug:
+                print(f"    vec_len={vec_len}: T={thread_cnt} carve failed")
+            continue
+        g_final_iters = [*outer_after_t, g_after_vec[-1]]
+        new_shape = [int(it.extent) for it in g_final_iters]
+        try:
+            s_final_grp, _ = s_aligned.group(new_shape)
+        except Exception as e:
+            if debug:
+                print(f"    vec_len={vec_len}: S.group({new_shape}) failed: {e}")
+            continue
+        g_p = TileLayout.from_iters(g_final_iters, list(g.replica), dict(g.offset))
+        s_p = s_final_grp
+
+        ok = _verify_s_tail_contig(s_p, vec_len)
+        if debug:
+            print(
+                f"    vec_len={vec_len}: shape={new_shape}, "
+                f"g_p.shard={[(int(it.extent), int(it.stride)) for it in g_p.shard]}, "
+                f"s_p.shard={[(int(it.extent), int(it.stride)) for it in s_p.shard]}, "
+                f"s_tail_contig={ok}"
+            )
+        if not ok:
+            continue
+        # Alignment: per-thread starting addr = base_ptr + sizeof(elem) *
+        # (region_base + tid*t_stride + outer_iter_strides). For the
+        # vec_bits/8 byte vector op to be naturally aligned, every one of
+        # those element-count terms must be a multiple of vec_len.
+        align_terms = []
+        for it in s_p.shard[:-1]:
+            align_terms.append(int(it.stride))
+        for it in g_p.shard[:-1]:
+            align_terms.append(int(it.stride))
+        align_terms.extend(s_p.offset.values())
+        align_terms.extend(g_p.offset.values())
+        if not _alignment_ok(vec_len, align_terms):
+            if debug:
+                print(f"    vec_len={vec_len}: alignment check failed")
+            continue
+        return g_p, s_p, vec_len
+
+    return g, s_aligned, 1
+
+
+def _flat_outer_coords(outer_exts: list[int], flat_idx: int) -> list[int]:
+    """Decode a row-major flat index into per-iter coords. ``outer_exts`` is
+    in stride-desc order (outermost first), so the first coord changes
+    slowest."""
+    coords: list[int] = []
+    rem = flat_idx
+    for ext in reversed(outer_exts):
+        coords.append(rem % ext)
+        rem //= ext
+    coords.reverse()
+    return coords
+
+
+def _outer_offsets(outer_iters_s, outer_iters_g, flat_idx):
+    """Returns ``(ds, dg)``: constant offsets on S and G sides for the
+    given flat outer-loop iteration."""
+    outer_exts = [int(it.extent) for it in outer_iters_s]
+    coords = _flat_outer_coords(outer_exts, flat_idx)
+    ds = sum(c * int(it.stride) for c, it in zip(coords, outer_iters_s))
+    dg = sum(c * int(it.stride) for c, it in zip(coords, outer_iters_g))
+    return ds, dg

--- a/python/tvm/backend/maca/operator/tile_primitive/copy/_swizzle_iter.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/copy/_swizzle_iter.py
@@ -1,0 +1,406 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Generic swizzle-aware iter pattern for MACA copy dispatches.
+
+When the per-thread outer-iter loop satisfies (C1)+(C2) below for a
+``SwizzleLayout(per_element=p, swizzle_len=sw, atom_len=at,
+swizzle_inner=True)`` on the SMEM side, the swizzled physical address
+at unrolled iter ``k`` reduces to
+
+    addr(k) = base_off + sum_{j : bit_j(k)=1} signed_strides[j]
+
+where ``base_off`` and the ``signed_strides[j]`` are per-thread runtime
+constants set once at thread setup. Per-iter cost is then ``popcount(k)``
+register adds instead of a full ``swizzle.apply(...)`` per iter.
+
+Notation. Each binary outer iter has element-stride ``2^(bj + p)`` for
+some chunk bit position ``bj >= 0`` (so ``stride / C = 2^bj`` where
+``C = 1 << p``). The chunk index ``q(M0) = M0 // C`` partitions into
+four bit ranges by where ``bj`` lands:
+
+  * ``[0, sw)``        — "inner" (Case 1.A in the proof)
+  * ``[sw, at)``       — "mid"   (Case 1.B)
+  * ``[at, at + sw)``  — "outer" (Case 1.C; the bit overlaps the swizzle
+                         outer mask, so its addition produces a
+                         secondary contribution at ``bj - at``)
+  * ``[at + sw, ∞)``   — "above" (Case 1.D)
+
+Conditions for the linear-combination fast path:
+
+  (C1) bit-clear no-carry: ``bit_bj(q(M0)) = 0`` for every binary iter.
+  (C2) support disjointness: no inner-outer pair ``(bj_A, bj_C)`` with
+       ``bj_C in [at, at+sw)`` and ``bj_A = bj_C - at`` both present.
+
+  (distinctness) The ``bj`` values across all binary iters must be
+       distinct — two iters at the same ``bj`` collapse into bit
+       ``bj + 1`` whose case behavior may differ.
+
+Under (C1)+(C2)+(distinctness), for each binary iter at position ``bj``:
+
+    T(bj)        = 2^(bj + p)            # element stride
+    sigma_b(M0)  = 1 - 2 * bit_b(q(M0))  # ∈ {+1, -1}
+
+    signed_strides[j] = sigma_(at + bj)(M0) * T(bj)        bj in [0, sw)
+                     = T(bj)                               bj in [sw, at)
+                     = T(bj) + sigma_(bj - at)(M0) * T(bj - at)
+                                                           bj in [at, at + sw)
+                     = T(bj)                               bj >= at + sw
+
+The ``swizzle_inner=False`` mode swaps the inner/outer roles and is not
+yet covered; ``try_recognize`` gates on this.
+"""
+
+from dataclasses import dataclass
+
+import tvm
+from tvm import arith
+from tvm.script import tirx as T
+from tvm.tirx.expr import IntImm as _IntImm
+from tvm.tirx.layout import ComposeLayout, SwizzleLayout
+
+
+@dataclass
+class _BitIter:
+    """Pow2-extent outer iter, binary-split into ``n_bits`` chunk-bit flips.
+
+    ``slot_start..slot_start + n_bits`` is this iter's range in the global
+    ``bit_positions`` / ``iter_strides_elems`` / ``signed_strides`` arrays.
+    Slot ``slot_start + b`` corresponds to bit position ``n_bits - 1 - b``
+    of this iter's per-iter coord (outermost binary bit first).
+    """
+
+    ext: int
+    n_bits: int
+    slot_start: int
+
+
+@dataclass
+class _LinearIter:
+    """Outer iter contributing ``c * stride`` to the offset (no bit decomp).
+
+    Used when ``stride`` is a multiple of ``2^(p + at + sw)`` (pure Case 1.D
+    regime: swizzle XOR has no effect on bits the iter flips). ``ext`` does
+    not need to be a power of two.
+    """
+
+    ext: int
+    stride: int
+
+
+@dataclass
+class SwizzlePattern:
+    """A recognized swizzle iter pattern.
+
+    ``bit_positions[j]`` and ``iter_strides_elems[j]`` collect the binary
+    sub-iters from every BitIter in outer-iter order (outermost first).
+    ``outer_iters`` lists every outer iter (BitIter or LinearIter) in
+    outermost-first order; ``emit_iter_offset`` walks this list to
+    decompose ``mm`` per-iter. Empty lists = trivially recognized
+    degenerate case (no outer iter, just base_off).
+    """
+
+    swizzle: SwizzleLayout
+    bit_positions: list[int]
+    iter_strides_elems: list[int]
+    outer_iters: "list[_BitIter | _LinearIter]"
+
+    @property
+    def n_binary_iters(self) -> int:
+        return len(self.bit_positions)
+
+
+def get_swizzle(layout) -> SwizzleLayout | None:
+    """Return the SwizzleLayout from ``layout`` if present, else ``None``.
+
+    Accepts ``ComposeLayout(SwizzleLayout, TileLayout)`` (the common case
+    when a TileLayout is wrapped by a swizzle), or a bare ``SwizzleLayout``.
+    """
+    if isinstance(layout, ComposeLayout):
+        return layout.swizzle
+    if isinstance(layout, SwizzleLayout):
+        return layout
+    return None
+
+
+def _is_pow2(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def try_recognize(
+    swizzle: SwizzleLayout,
+    iter_extents: list[int],
+    iter_strides: list[int],
+    s_off_template,
+    var_bounds: dict | None = None,
+) -> SwizzlePattern | None:
+    """Return a ``SwizzlePattern`` if (C1)+(C2)+(distinctness) hold, else ``None``.
+
+    ``iter_extents`` / ``iter_strides``: the outer-iter list on the S side
+    (excluding T iter and vec iter), in outermost-first order matching
+    ``s_p.shard[:-2]`` (or the atom-derived analog in ``reg.py``).
+    Strides are in element units.
+
+    Each outer iter with ``extent=2^k`` and ``stride=s`` is conceptually
+    split into ``k`` binary iters of strides ``2^(k-1)*s, ..., 2*s, s``
+    (outermost first within the split — this matches ``_flat_outer_coords``
+    semantics, since the highest-stride iter must change slowest in the
+    flat-index decomposition).
+
+    ``s_off_template`` is the per-thread linear base offset expression
+    (with a placeholder var for the thread-id contribution). It is used
+    only to check condition (C1) symbolically via ``arith.Analyzer``;
+    ``emit_init`` takes the resolved form separately.
+
+    ``var_bounds`` is an optional ``{Var: tvm.ir.Range}`` map of placeholder
+    bounds to ``analyzer.bind`` before the (C1) check. Without bounds,
+    structurally-OK forms like ``(lane // 8) * 8 + (lane % 8) * Q`` where
+    ``lane < 32`` make ``(... // (C·2^bj)) % 2 == 0`` unprovable — the
+    bit is in fact always 0 but the analyzer can't conclude it universally.
+    Pass ``{lane_ph: Range(0, 32), warp_ph: Range(0, n_warps)}`` (or the
+    scope's equivalents) to let the (C1) check fire on these templates.
+    """
+    # swizzle_inner=False swaps the inner/outer xor direction — Cases 1.A
+    # and 1.C roles flip. Not derived/tested yet; reject for safety.
+    if not swizzle.swizzle_inner:
+        return None
+
+    p = swizzle.per_element
+    sw = swizzle.swizzle_len
+    at = swizzle.atom_len
+    C = 1 << p
+    # Pure Case 1.D threshold: stride a multiple of this means every chunk-bit
+    # the iter flips is at position >= at + sw (above the swizzle XOR region),
+    # so swizzle has no effect and the contribution is purely linear in the
+    # iter coord — no power-of-2 ext requirement.
+    pure_1d = 1 << (p + at + sw)
+
+    bit_positions: list[int] = []
+    iter_strides_elems: list[int] = []
+    outer_iters: list = []
+
+    for ext, stride in zip(iter_extents, iter_strides):
+        # Zero-stride iters degrade dq=0 → log2 undefined. Explicit guard.
+        if stride == 0 or stride % C != 0:
+            return None
+        if ext <= 0:
+            return None
+        if ext == 1:
+            # Trivial iter contributes nothing; skip without forcing pow2.
+            continue
+        if not _is_pow2(ext):
+            # Non-pow2 ext can only be handled by the linear path. That in turn
+            # requires the iter to be in pure Case 1.D (stride a multiple of
+            # the swizzle period) so the swizzle does not interact with the
+            # per-coord contribution.
+            if stride % pure_1d != 0:
+                return None
+            outer_iters.append(_LinearIter(ext=ext, stride=stride))
+            continue
+        # pow2 ext: binary split (existing path).
+        k = ext.bit_length() - 1  # log2(ext)
+        slot_start = len(bit_positions)
+        # Split into k binary iters; the outermost (within this split) carries
+        # the largest stride so that flat-index bit decomp matches our
+        # outer-iter list ordering.
+        for j in range(k - 1, -1, -1):
+            substride = stride * (1 << j)
+            dq = substride // C
+            # dq must be a single bit set (so this binary iter flips exactly
+            # one bit of the chunk index). _is_pow2 also rejects dq=0.
+            if not _is_pow2(dq):
+                return None
+            bj = dq.bit_length() - 1
+            # All bj >= 0 accepted; case branching happens in emit_init.
+            bit_positions.append(bj)
+            iter_strides_elems.append(substride)
+        outer_iters.append(_BitIter(ext=ext, n_bits=k, slot_start=slot_start))
+
+    # Distinctness: two binary iters at the same bj collapse to bj+1, whose
+    # case behavior may differ from bj. See module docstring NB.
+    if len(set(bit_positions)) != len(bit_positions):
+        return None
+
+    bj_set = set(bit_positions)
+
+    # (C2) support disjointness: the only possible collision is between a
+    # Case-1.A iter at bj_A and a Case-1.C iter at bj_A + at. Checking the
+    # 1.C direction alone is symmetric and complete.
+    for bj in bj_set:
+        if at <= bj < at + sw and (bj - at) in bj_set:
+            return None  # inner-outer pair collision
+
+    # (C1) per-iter no-carry on q(M0). Must hold *symbolically over all*
+    # free lane / warp placeholders in s_off_template — ``can_prove_equal``
+    # returns False if the analyzer can't discharge the equality
+    # universally, conservatively forcing a fallback.
+    analyzer = arith.Analyzer()
+    if var_bounds:
+        for var, rng in var_bounds.items():
+            analyzer.bind(var, rng)
+    for bj in bj_set:
+        divisor = C * (1 << bj)
+        check = tvm.tirx.floormod(
+            tvm.tirx.floordiv(s_off_template, _IntImm("int32", divisor)),
+            _IntImm("int32", 2),
+        )
+        if not analyzer.can_prove_equal(check, _IntImm("int32", 0)):
+            return None
+
+    return SwizzlePattern(
+        swizzle=swizzle,
+        bit_positions=bit_positions,
+        iter_strides_elems=iter_strides_elems,
+        outer_iters=outer_iters,
+    )
+
+
+def emit_init(pattern: SwizzlePattern, s_off_resolved):
+    """Emit at thread setup (call from inside the @T.prim_func body):
+
+      1. ``base_off = swizzle.apply(s_off_resolved)`` — runtime, per-thread,
+         computed once.
+      2. ``signed_strides[j]`` for each binary iter j, written into a local
+         buffer using the sigma formula above.
+
+    Returns ``(signed_strides_buffer_or_None, base_off_primexpr)``. The
+    buffer is ``None`` when ``pattern.n_binary_iters == 0`` (no outer
+    iter, no signed_strides needed).
+
+    ``s_off_resolved`` is the per-thread offset with the real tid Var
+    substituted in (not the placeholder).
+    """
+    swizzle = pattern.swizzle
+    p = swizzle.per_element
+    sw = swizzle.swizzle_len
+    at = swizzle.atom_len
+    C = 1 << p
+
+    base_off = swizzle.apply(s_off_resolved)["m"]
+
+    n = pattern.n_binary_iters
+    if n == 0:
+        return None, base_off
+
+    signed_strides = T.alloc_buffer([n], "int32", scope="local")
+    q = tvm.tirx.floordiv(s_off_resolved, C)
+
+    def _sigma_bit(bit_pos: int):
+        # 1 - 2 * bit_(bit_pos)(q); ∈ {+1, -1}.
+        row_bit = tvm.tirx.bitwise_and(
+            tvm.tirx.shift_right(q, _IntImm("int32", bit_pos)),
+            _IntImm("int32", 1),
+        )
+        return _IntImm("int32", 1) - row_bit * _IntImm("int32", 2)
+
+    for j, (bj, stride) in enumerate(zip(pattern.bit_positions, pattern.iter_strides_elems)):
+        stride_pow = stride  # = 2^(bj + p) elements
+        if 0 <= bj < sw:
+            # Case 1.A (inner): signed_stride = sigma_(at + bj) · T.
+            value = _sigma_bit(at + bj) * _IntImm("int32", stride_pow)
+        elif sw <= bj < at:
+            # Case 1.B (mid): signed_stride = +T.
+            value = _IntImm("int32", stride_pow)
+        elif at <= bj < at + sw:
+            # Case 1.C (outer): signed_stride = T + sigma_(bj - at) · T_sec.
+            # Invariant: bj >= at, so T_sec = T >> at = 2^(bj - at + p)
+            # = T(bj - at) is well-defined (no underflow).
+            stride_sec = stride_pow >> at
+            value = _IntImm("int32", stride_pow) + _sigma_bit(bj - at) * _IntImm(
+                "int32", stride_sec
+            )
+        else:  # bj >= at + sw, Case 1.D (above)
+            # No swizzle effect at this bit; signed_stride = +T.
+            value = _IntImm("int32", stride_pow)
+        # NB: Buffer.__setitem__ syntax (``signed_strides[j] = value``) is
+        # intercepted by the TIRx script parser but not by raw Python when
+        # this function is called from outside an @T.inline body. Use the
+        # low-level buffer_store builder instead.
+        T.buffer_store(signed_strides, value, [_IntImm("int32", j)])
+
+    return signed_strides, base_off
+
+
+def emit_iter_offset(pattern: SwizzlePattern, signed_strides, base_off, k):
+    """Compute the per-mm physical S offset = ``base_off`` + sum of per-iter
+    contributions.
+
+    ``k`` is the flat outer iter index ∈ ``[0, prod(it.ext for it in outer_iters))``.
+    Decomposed innermost-first across ``pattern.outer_iters`` into per-iter
+    coords ``c_i``. Each iter contributes:
+
+      * ``_BitIter``: ``sum_b bit_(n_bits-1-b)(c_i) * signed_strides[slot_start + b]``,
+        i.e. each binary bit of ``c_i`` selects its precomputed sigma-stride.
+        The slot order (outermost-first within the iter) means the highest
+        bit of ``c_i`` indexes the slot at ``slot_start``.
+      * ``_LinearIter``: ``c_i * stride`` (no bit decomposition; used when
+        ``stride`` is a multiple of ``2^(p + at + sw)`` so swizzle has no
+        XOR effect and ``ext`` need not be pow2).
+
+    Two paths per iter:
+      * Python int ``k`` — coords and bits known at parse time; emits only
+        the necessary adds, no runtime shift/mask.
+      * TIRx Var ``k`` — emits floormod/floordiv + bit-and/shift; relies on
+        downstream unroll + constant-fold.
+    """
+    if not pattern.outer_iters:
+        return base_off
+
+    off = base_off
+    remaining = k
+    is_const = isinstance(k, int)
+    for it in reversed(pattern.outer_iters):  # innermost first
+        ext = it.ext
+        if is_const:
+            c = remaining % ext
+            remaining = remaining // ext
+        else:
+            c = tvm.tirx.floormod(remaining, _IntImm("int32", ext))
+            remaining = tvm.tirx.floordiv(remaining, _IntImm("int32", ext))
+        if isinstance(it, _LinearIter):
+            if is_const:
+                if c != 0:
+                    off = off + c * it.stride
+            else:
+                off = off + c * _IntImm("int32", it.stride)
+            continue
+        # _BitIter
+        for b in range(it.n_bits):
+            bit_pos = it.n_bits - 1 - b
+            slot = it.slot_start + b
+            if is_const:
+                if (c >> bit_pos) & 1:
+                    off = off + signed_strides[slot]
+            else:
+                bit = tvm.tirx.bitwise_and(
+                    tvm.tirx.shift_right(c, _IntImm("int32", bit_pos)),
+                    _IntImm("int32", 1),
+                )
+                off = off + bit * signed_strides[slot]
+    return off
+
+
+def emit_fallback_offset(swizzle: SwizzleLayout, s_off_resolved, ds_k):
+    """Slow but always-correct path: full ``swizzle.apply(s_off + ds_k)``
+    per iter. Use when ``try_recognize`` returns ``None``.
+
+    ``ds_k`` is the outer-iter delta for unrolled iter k — typically a
+    PrimExpr (a function of the unroll var that simplifies to a constant
+    after unrolling) or a Python int. ``s_off_resolved`` is the per-thread
+    base linear offset with the real tid Var substituted.
+    """
+    return swizzle.apply(s_off_resolved + ds_k)["m"]

--- a/python/tvm/backend/maca/operator/tile_primitive/copy/fallback.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/copy/fallback.py
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Scalar single-thread copy fallback (priority=0)."""
+
+import warnings
+
+import tvm
+from tvm.script import tirx as T
+from tvm.tirx import Buffer, PrimFunc
+from tvm.tirx.operator.tile_primitive.dispatcher import (
+    predicate,
+    register_dispatch,
+)
+from tvm.tirx.operator.tile_primitive.registry import DispatchContext
+from tvm.tirx.stmt import TilePrimitiveCall
+
+from ._common import _TID_AXIS_FOR_SCOPE
+from .reg import _axis_decl
+from .utils import _is_valid_copy
+
+
+def _region_st_extent(buffer_region):
+    region = buffer_region.region
+    return [r.min for r in region], [r.extent for r in region]
+
+
+def _emit_fallback(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
+    op_call = TilePrimitiveCall.downcast(op_call)
+    src: Buffer = op_call.src.buffer
+    dst: Buffer = op_call.dst.buffer
+    src_st, src_extent = _region_st_extent(op_call.src)
+    dst_st, dst_extent = _region_st_extent(op_call.dst)
+
+    warnings.warn(
+        f"copy/fallback (scalar single-thread) picked for {src.scope()} -> "
+        f"{dst.scope()} at scope_kind={sctx.scope_kind}; all faster variants "
+        f"rejected.",
+        stacklevel=2,
+    )
+
+    def _copy_body(dst_buf, src_buf):
+        dst_indices = [i for i in range(len(dst_buf.shape)) if dst_extent[i] != 1]
+        src_indices = [i for i in range(len(src_buf.shape)) if src_extent[i] != 1]
+        assert len(dst_indices) == len(src_indices)
+        copy_extents = [dst_extent[i] for i in dst_indices]
+
+        def _dst_coord(lvs):
+            if isinstance(lvs, tvm.tirx.Var):
+                lvs = [lvs]
+            coord = list(dst_st)
+            for k, lv in enumerate(lvs):
+                coord[dst_indices[k]] += lv
+            return coord
+
+        def _src_coord(lvs):
+            if isinstance(lvs, tvm.tirx.Var):
+                lvs = [lvs]
+            coord = list(src_st)
+            for k, lv in enumerate(lvs):
+                coord[src_indices[k]] += lv
+            return coord
+
+        with T.grid(*copy_extents) as lvs:
+            T.buffer_store(dst_buf, src_buf[tuple(_src_coord(lvs))], _dst_coord(lvs))
+
+    scope_kind = sctx.scope_kind
+
+    if scope_kind == "thread":
+
+        @T.prim_func(check_well_formed=False)
+        def impl():
+            _copy_body(dst, src)
+
+        return impl
+
+    tid_axis_name = _TID_AXIS_FOR_SCOPE[scope_kind]
+    # first-active tid = composition of per-axis offsets (radix-64, since a warp is 64 lanes)
+    first_tid = int(sctx.intra["laneid"][1])
+    if scope_kind == "cta":
+        first_tid += 64 * int(sctx.intra["warpid"][1])
+
+    @T.prim_func(check_well_formed=False)
+    def impl():
+        tid = _axis_decl(tid_axis_name, sctx)
+        if tid == first_tid:
+            _copy_body(dst, src)
+
+    return impl
+
+
+@register_dispatch(
+    "copy",
+    "maca",
+    variant="fallback",
+    priority=0,
+    when=[predicate("validate_copy_op", _is_valid_copy)],
+)
+def copy_schedule_fallback(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
+    return _emit_fallback(op_call, sctx)

--- a/python/tvm/backend/maca/operator/tile_primitive/copy/gmem_smem.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/copy/gmem_smem.py
@@ -1,0 +1,303 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""MACA copy dispatch for ``global ↔ shared`` (no register side).
+
+There's no per-thread register side to inherit a partition from — both sides
+are cross-thread storage. The partition is synthesized from the surrounding
+scope context (warp / warpgroup / cta / thread): ``thread_cnt`` is derived
+from ``sctx.intra`` and each thread takes ``n_elements / thread_cnt``
+consecutive fused-index slots. Layout / partition algorithm lives in
+``_common.py`` and is shared with ``ldgsts.py``.
+"""
+
+import tvm
+from tvm.runtime import DataType
+from tvm.script import tirx as T
+from tvm.tirx import Buffer, PrimFunc
+from tvm.tirx import Var as _TirVar
+from tvm.tirx.expr import IntImm as _IntImm
+from tvm.tirx.operator.tile_primitive.dispatcher import (
+    predicate,
+    register_dispatch,
+)
+from tvm.tirx.operator.tile_primitive.registry import DispatchContext
+from tvm.tirx.stmt import TilePrimitiveCall
+
+from ._common import (
+    _TID_AXIS_FOR_SCOPE,
+    _thread_cnt,
+    align_layouts_gs,
+)
+from ._swizzle_iter import (
+    emit_init,
+    emit_iter_offset,
+    get_swizzle,
+    try_recognize,
+)
+from .reg import _all_threads_active, _axis_decl, _ptr_off
+from .utils import _is_valid_copy, _scope_allowed
+
+_GMEM_SMEM_PAIRS = [
+    ("global", "shared*"),
+    ("shared*", "global"),
+]
+
+
+def _divides_thread_cnt(
+    op_call: TilePrimitiveCall, sctx: DispatchContext
+) -> tuple[bool, str | None]:
+    """Reject copies whose region element count does not divide ``thread_cnt``.
+
+    Without this guard the emit's ``[outer, T, vec]`` partition has no
+    integer solution: either every thread gets fractional work, or
+    ``thread_cnt=0`` (degenerate scope) hits a modulo-by-zero. Both cases
+    indicate a poorly-shaped copy (e.g. 1024-thread CTA writing a 64-elem
+    tail) that this dispatch refuses to paper over with a slow scalar emit.
+    """
+    op_call = TilePrimitiveCall.downcast(op_call)
+    thread_cnt = _thread_cnt(sctx)
+    if thread_cnt <= 0:
+        return False, f"degenerate thread_cnt={thread_cnt} (scope has empty intra)"
+    g_br = op_call.src if op_call.src.buffer.scope() == "global" else op_call.dst
+    n_elements = 1
+    for r in g_br.region:
+        ext = r.extent
+        try:
+            n_elements *= int(ext)
+        except (TypeError, ValueError):
+            return False, f"non-constant region extent {ext}"
+    if n_elements % thread_cnt != 0:
+        return False, (f"region size {n_elements} not divisible by thread_cnt={thread_cnt}")
+    return True, None
+
+
+def _is_gmem_smem(op_call: TilePrimitiveCall, sctx: DispatchContext) -> tuple[bool, str | None]:
+    if not sctx.is_target("maca"):
+        return False, "non-maca target"
+    if sctx.scope_kind not in ("thread", "warp", "cta"):
+        return False, f"unsupported exec_scope {sctx.scope_kind}"
+    for check in (
+        lambda: _all_threads_active(sctx),
+        lambda: _is_valid_copy(op_call, sctx),
+        lambda: _scope_allowed(op_call, sctx, allowed_pairs=_GMEM_SMEM_PAIRS),
+        lambda: _divides_thread_cnt(op_call, sctx),
+    ):
+        ok, msg = check()
+        if not ok:
+            return False, msg
+    return True, None
+
+
+def _emit_gmem_smem(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
+    op_call = TilePrimitiveCall.downcast(op_call)
+    src: Buffer = op_call.src.buffer
+    dst: Buffer = op_call.dst.buffer
+    if src.scope() == "global":
+        g_buf, g_br, s_buf, s_br = src, op_call.src, dst, op_call.dst
+        g_is_src = True
+    else:
+        g_buf, g_br, s_buf, s_br = dst, op_call.dst, src, op_call.src
+        g_is_src = False
+
+    g_region = [(r.min, r.min + r.extent) for r in g_br.region]
+    s_region = [(r.min, r.min + r.extent) for r in s_br.region]
+
+    elem_bits = DataType(src.dtype).bits
+    thread_cnt = _thread_cnt(sctx)
+
+    with sctx.target:
+        g_p, s_p, vec_len = align_layouts_gs(
+            g_buf.layout,
+            g_buf.shape,
+            g_region,
+            s_buf.layout,
+            s_buf.shape,
+            s_region,
+            elem_bits,
+            thread_cnt,
+        )
+
+    # vec_len=1 is the scalar fallback — uses the same unified
+    # [outer x thread x vec] coord scheme below.
+
+    vec_bits = vec_len * elem_bits
+    copy_op = getattr(T.maca, f"copy_{vec_bits}b")
+
+    # Partition guarantees ``prod(s_p.shard.extents) == prod(g_p.shard.extents)
+    # == n_elements`` (the total transfer count). Express the per-thread
+    # per-round address as a 3D coord ``(f, tid, 0)`` against shape
+    # ``[total_outer, thread_cnt, vec_len]``, and let ``layout.apply`` flatten
+    # it through whatever multi-iter T / outer-iter structure ``align_layouts_gs``
+    # picked. This makes the emit oblivious to how many iters the partition
+    # split T or outer across.
+    n_elements = 1
+    for it in s_p.shard:
+        n_elements *= int(it.extent)
+    assert n_elements % (thread_cnt * vec_len) == 0, (
+        f"partition produced {n_elements} elements but thread_cnt({thread_cnt}) * "
+        f"vec_len({vec_len}) = {thread_cnt * vec_len} doesn't divide it"
+    )
+    total_outer = n_elements // (thread_cnt * vec_len)
+    apply_shape = [
+        _IntImm("int32", total_outer),
+        _IntImm("int32", thread_cnt),
+        _IntImm("int32", vec_len),
+    ]
+
+    s_zero = [0] * len(s_buf.shape)
+    g_zero = [0] * len(g_buf.shape)
+
+    tid_axis_name = _TID_AXIS_FOR_SCOPE[sctx.scope_kind] if thread_cnt > 1 else None
+
+    # Walk shard from the vec iter backward to find the prefix that covers
+    # the T region exactly (∏ext == thread_cnt). The iters consumed are T
+    # iters; the leading prefix is the outer iter list — handed to
+    # ``try_recognize`` so the swizzle fast path can decide whether the
+    # outer iter strides match a pattern it can lower to signed_strides.
+    if thread_cnt > 1:
+        acc, _i = 1, len(s_p.shard) - 2
+        while _i >= 0 and acc < thread_cnt:
+            _ext = int(s_p.shard[_i].extent)
+            if acc * _ext > thread_cnt:
+                break
+            acc *= _ext
+            _i -= 1
+        outer_iters_s = list(s_p.shard[: _i + 1]) if acc == thread_cnt else []
+    else:
+        outer_iters_s = list(s_p.shard[:-1])
+
+    # SwizzleLayout on s_buf: try the closed-form signed-strides pattern
+    # (precomputed once per thread, then per-iter is a sum of register
+    # adds); fall back to per-iter ``swizzle.apply`` (one full XOR +
+    # decompose per iter). Closure picked at parse time so the TIRx parser
+    # doesn't AST-evaluate a "dead" ternary branch.
+    swizzle = get_swizzle(s_buf.layout)
+    swizzle_pattern = None
+    if swizzle is not None and outer_iters_s:
+        if tid_axis_name is not None:
+            _tid_placeholder = _TirVar(tid_axis_name, "int32")
+        else:
+            _tid_placeholder = _IntImm("int32", 0)
+        s_off_template = s_p.apply(
+            _IntImm("int32", 0),
+            _tid_placeholder,
+            _IntImm("int32", 0),
+            shape=apply_shape,
+        )["m"]
+        # Bind the tid placeholder's range so the (C1) analyzer check can
+        # discharge ``bit_bj(s_off // C) == 0`` for high bj's. Outer iter
+        # stride here is ``thread_cnt * vec_len`` ⇒ bj ∈ [log2(thread_cnt),
+        # ...]; without bounds the analyzer can't prove the lane's high bits
+        # are 0 and rejects.
+        var_bounds = {}
+        if tid_axis_name is not None:
+            var_bounds[_tid_placeholder] = tvm.ir.Range.from_min_extent(0, thread_cnt)
+        swizzle_pattern = try_recognize(
+            swizzle,
+            [int(it.extent) for it in outer_iters_s],
+            [int(it.stride) for it in outer_iters_s],
+            s_off_template,
+            var_bounds=var_bounds or None,
+        )
+
+    class _SwizzleState:
+        def __init__(self):
+            self.signed_strides = None
+            self.base_off = None
+
+    state = _SwizzleState()
+
+    def _decl_tid():
+        if tid_axis_name is not None:
+            return _axis_decl(tid_axis_name, sctx)
+        return _IntImm("int32", 0)
+
+    def _setup_swizzle(tid):
+        if swizzle_pattern is None:
+            return
+        s_off_resolved = s_p.apply(
+            _IntImm("int32", 0),
+            tid,
+            _IntImm("int32", 0),
+            shape=apply_shape,
+        )["m"]
+        state.signed_strides, state.base_off = emit_init(
+            swizzle_pattern,
+            s_off_resolved,
+        )
+
+    if swizzle_pattern is not None:
+
+        def _s_off(f, s_lin):
+            return emit_iter_offset(
+                swizzle_pattern,
+                state.signed_strides,
+                state.base_off,
+                f,
+            )
+    elif swizzle is not None:
+        _sw = swizzle
+
+        def _s_off(f, s_lin):
+            return _sw.apply(s_lin)["m"]
+    else:
+
+        def _s_off(f, s_lin):
+            return s_lin
+
+    v0 = _IntImm("int32", 0)
+
+    # fmt: off
+    @T.prim_func(check_well_formed=False)
+    def impl():
+        tid = _decl_tid()
+        _setup_swizzle(tid)
+        # NB: pass typed ptr_to(...) directly to _ptr_off; caching in a
+        # local var turns it into void* + offset = byte arithmetic →
+        # misaligned vector ops.
+        #
+        # Use a serial TIR loop and let the backend compiler unroll downstream. Mirrors
+        # the reg.py rationale in commit ac7ecf70f0: explicit ``T.unroll``
+        # materializes the per-iter scratch (s_lin/g_lin/s_off/s_ptr/g_ptr)
+        # as N copies of each ``alignas(64)`` declaration. For large
+        # ``total_outer`` (e.g. thread-scope fp32 swizzled copies of 32x256
+        # at vec=4 ⇒ 2048 iters; ldgsts test4 ⇒ ~4k iters once both
+        # g2s/s2g sites add up) this floods the kernel and backend compilation times out.
+        for f in range(total_outer):
+            s_lin = s_p.apply(f, tid, v0, shape=apply_shape)["m"]
+            g_lin = g_p.apply(f, tid, v0, shape=apply_shape)["m"]
+            s_off = _s_off(f, s_lin)
+            s_ptr = _ptr_off(s_buf.ptr_to(s_zero), s_off)
+            g_ptr = _ptr_off(g_buf.ptr_to(g_zero), g_lin)
+            if g_is_src:
+                copy_op(s_ptr, g_ptr)
+            else:
+                copy_op(g_ptr, s_ptr)
+    # fmt: on
+    return impl
+
+
+@register_dispatch(
+    "copy",
+    "maca",
+    variant="gmem_smem",
+    priority=10,
+    when=[predicate("gmem_smem_applicable", _is_gmem_smem)],
+)
+def copy_schedule_gmem_smem(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
+    return _emit_gmem_smem(op_call, sctx)

--- a/python/tvm/backend/maca/operator/tile_primitive/copy/reg.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/copy/reg.py
@@ -1,0 +1,593 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Non-ldmatrix copy dispatch for register ↔ memory.
+
+This file owns every copy where one side is per-thread local (``R`` =
+register). That R side carries the partition: its ``TileLayout`` ``shard``
+has thread-axis iters telling us which thread owns which logical coordinate.
+The other side (``S``) can be ``shared*`` or ``global`` — the algorithm is
+identical either way.
+
+Slice/canonicalize both sides, align via perm+group, then emit a per-thread
+vectorized copy loop. Direction-symmetric: covers R2S / S2R / R2G / G2R.
+"""
+
+import tvm
+from tvm.arith import Analyzer
+from tvm.runtime import DataType
+from tvm.script import tirx as T
+from tvm.tirx import Buffer, PrimFunc
+from tvm.tirx import Var as _TirVar
+from tvm.tirx.expr import IntImm as _IntImm
+from tvm.tirx.layout import ComposeLayout, S, SwizzleLayout, TileLayout
+from tvm.tirx.operator.tile_primitive.dispatcher import predicate, register_dispatch
+from tvm.tirx.operator.tile_primitive.registry import DispatchContext
+from tvm.tirx.stmt import TilePrimitiveCall
+
+from ._common import _alignment_ok
+from ._swizzle_iter import (
+    emit_fallback_offset,
+    emit_init,
+    emit_iter_offset,
+    get_swizzle,
+    try_recognize,
+)
+from .utils import _is_valid_copy, _scope_allowed
+
+
+def _extract_tile(layout, region):
+    """Strip swizzle off ``layout`` so we can perm/group it as a TileLayout.
+
+    ``region`` is the per-axis ``(start, end)`` pair list — we only consume
+    its extents when ``layout`` is a bare ``SwizzleLayout`` (rebuilding a
+    trivial TileLayout for it). Plain ``TileLayout`` / ``ComposeLayout``
+    don't need the extent, so symbolic regions are fine for them.
+    """
+    if isinstance(layout, ComposeLayout):
+        return layout.tile_layout
+    if isinstance(layout, SwizzleLayout):
+        # TODO: keep swizzle info around for later (addressing in emit).
+        extents = [int(end - start) for (start, end) in region]
+        return TileLayout(S[tuple(extents)])
+    return layout
+
+
+_REG_PAIRS = [
+    ("local", "shared*"),
+    ("shared*", "local"),
+    ("local", "global"),
+    ("global", "local"),
+]
+_SCOPE_RANK = {"thread": 0, "warp": 1, "warpgroup": 2, "cta": 3}
+_VALID_R_SUBSCOPES = {"thread", "warp", "warpgroup"}
+
+
+def _all_threads_active(sctx: DispatchContext) -> tuple[bool, str | None]:
+    if sctx.scope_kind == "thread":
+        return True, None
+    required: dict[str, int] = {}
+    if sctx.scope_kind in ("warp", "warpgroup", "cta"):
+        required["laneid"] = 64
+    if sctx.scope_kind == "cta":
+        tx_iv = sctx.launch_params.get("threadIdx.x")
+        if tx_iv is None:
+            return False, "cta scope missing threadIdx.x launch_params"
+        try:
+            required["warpid"] = int(tx_iv.dom.extent) // 64
+        except (TypeError, ValueError):
+            return False, f"non-static threadIdx.x extent: {tx_iv.dom.extent}"
+    for axis_name, expected in required.items():
+        if axis_name not in sctx.intra:
+            return False, f"sctx.intra missing {axis_name!r}"
+        ext_raw, off_raw = sctx.intra[axis_name]
+        try:
+            ext, off = int(ext_raw), int(off_raw)
+        except (TypeError, ValueError):
+            return False, f"non-static range for {axis_name}: ({ext_raw}, {off_raw})"
+        if ext != expected or off != 0:
+            return False, f"{axis_name} narrowed to [{off}, {off + ext}) vs full [0, {expected})"
+    return True, None
+
+
+def _r_side_layout_valid(
+    op_call: TilePrimitiveCall, sctx: DispatchContext
+) -> tuple[bool, str | None]:
+    op_call = TilePrimitiveCall.downcast(op_call)
+    src: Buffer = op_call.src.buffer
+    dst: Buffer = op_call.dst.buffer
+    r_buf = src if src.scope() == "local" else dst
+    layout = r_buf.layout
+    if layout is None:
+        return False, "R has no layout"
+    if layout.is_swizzle():
+        return False, "R layout is swizzle"
+    if not isinstance(layout, TileLayout):
+        return False, f"R layout is {type(layout).__name__}, not TileLayout"
+
+    scope_rank = _SCOPE_RANK[sctx.scope_kind]
+    seen_thread_axes: set[str] = set()
+    for it in layout.shard:
+        ax = it.axis
+        if not ax.is_thread():
+            continue
+        ax_scope = ax.get_scope()
+        ax_sub = ax.get_subscope()
+        if ax_scope is None or ax_sub is None:
+            return False, f"R thread axis {ax.name!r} missing scope/subscope"
+        if ax_sub.name not in _VALID_R_SUBSCOPES:
+            return False, f"R thread axis {ax.name!r} subscope={ax_sub.name!r} (not register-level)"
+        if ax_scope.name not in _SCOPE_RANK or _SCOPE_RANK[ax_scope.name] > scope_rank:
+            return (
+                False,
+                f"R thread axis {ax.name!r} scope={ax_scope.name!r} > exec {sctx.scope_kind!r}",
+            )
+        # TODO: lift these two; for now i = thread_value (stride=1, each axis appears once).
+        if int(it.stride) != 1:
+            return (
+                False,
+                f"R thread axis {ax.name!r} stride={int(it.stride)} != 1 (not supported yet)",
+            )
+        if ax.name in seen_thread_axes:
+            return False, f"R thread axis {ax.name!r} appears more than once (not supported yet)"
+        seen_thread_axes.add(ax.name)
+
+    r_br = op_call.src if src.scope() == "local" else op_call.dst
+    region = [(r.min, r.min + r.extent) for r in r_br.region]
+    sliced = layout.slice(list(r_buf.shape), region)
+    if sliced is None:
+        return False, "R layout slice failed"
+    analyzer = Analyzer()
+    for axis, off in sliced.offset.items():
+        if axis.is_thread() and not analyzer.can_prove_equal(off, 0):
+            return False, f"R sliced offset on thread axis {axis.name!r} = {off}"
+    return True, None
+
+
+def _s_side_slice_ok(op_call: TilePrimitiveCall) -> tuple[bool, str | None]:
+    """S is the non-local side (shared* or global). Slice must succeed."""
+    op_call = TilePrimitiveCall.downcast(op_call)
+    src_br = op_call.src
+    dst_br = op_call.dst
+    s_br = dst_br if src_br.buffer.scope() == "local" else src_br
+    s_buf: Buffer = s_br.buffer
+    layout = s_buf.layout
+    if layout is None:
+        return False, "S has no layout"
+    region = [(r.min, r.min + r.extent) for r in s_br.region]
+    if layout.slice(list(s_buf.shape), region) is None:
+        return False, "S layout slice failed"
+    return True, None
+
+
+def _is_reg_copy(op_call: TilePrimitiveCall, sctx: DispatchContext) -> tuple[bool, str | None]:
+    if not sctx.is_target("maca"):
+        return False, "non-maca target"
+    if sctx.scope_kind not in ("thread", "warp", "cta"):
+        return False, f"unsupported exec_scope {sctx.scope_kind}"
+    for check in (
+        lambda: _all_threads_active(sctx),
+        lambda: _is_valid_copy(op_call, sctx),
+        lambda: _scope_allowed(op_call, sctx, allowed_pairs=_REG_PAIRS),
+        lambda: _r_side_layout_valid(op_call, sctx),
+        lambda: _s_side_slice_ok(op_call),
+    ):
+        ok, msg = check()
+        if not ok:
+            return False, msg
+    return True, None
+
+
+def _compute_perm_r(r):
+    # thread axes first, then by stride descending
+    def key(p):
+        it = p[1]
+        return (0 if it.axis.is_thread() else 1, -int(it.stride))
+
+    return [i for i, _ in sorted(enumerate(r.shard), key=key)]
+
+
+def align_layouts_raw(r_layout, r_shape, r_region, s_layout, s_shape, s_region):
+    """Returns (r_p, s_p, s_seps)."""
+    r = r_layout.slice(list(r_shape), r_region).canonicalize()
+    s = s_layout.slice(list(s_shape), s_region).canonicalize()
+    s = _extract_tile(s, s_region)
+    perm = _compute_perm_r(r)
+    r_shape_for_group = [int(it.extent) for it in r.shard]
+    s_grp, seps = s.group(r_shape_for_group)
+    s_p = s_grp.permute_by_groups(list(seps), perm)
+    r_p = r.permute_dims(perm).canonicalize()
+    sizes = [seps[i + 1] - seps[i] for i in range(len(seps) - 1)]
+    s_seps = [0]
+    for p in perm:
+        s_seps.append(s_seps[-1] + sizes[p])
+    return r_p, s_p, s_seps
+
+
+def _split_thread_loop(r_p, s_p, s_seps):
+    """Drop R's thread-axis positions and return per-R-position bundles:
+    (r_iters, s_groups) — same length lists; s_groups[k] is the list of S
+    iters belonging to the k-th kept R position."""
+    r_iters = []
+    s_groups = []
+    for k, r_it in enumerate(r_p.shard):
+        if r_it.axis.is_thread():
+            continue
+        r_iters.append(r_it)
+        s_groups.append(list(s_p.shard[s_seps[k] : s_seps[k + 1]]))
+    return r_iters, s_groups
+
+
+def _build_atoms(r_iters, s_groups):
+    """One atom per (R position, intra-group S iter): (extent, s_stride, r_mul).
+    r_mul = R_stride_at_position * (product of S group extents to the right
+    of this intra-position index) — i.e. how much R address advances per unit
+    of this iter's loop input."""
+    atoms = []
+    for r_it, s_group in zip(r_iters, s_groups, strict=True):
+        rs = int(r_it.stride)
+        extents = [int(it.extent) for it in s_group]
+        for j, s_it in enumerate(s_group):
+            inner_prod = 1
+            for e in extents[j + 1 :]:
+                inner_prod *= e
+            atoms.append((int(s_it.extent), int(s_it.stride), rs * inner_prod))
+    return atoms
+
+
+def _atoms_contiguous_tail_extent(atoms) -> int:
+    """Like _contiguous_tail_extent but on atoms (uses s_stride for chaining)."""
+    if not atoms or atoms[-1][1] != 1:
+        return 0
+    acc = atoms[-1][0]
+    for k in range(len(atoms) - 2, -1, -1):
+        if atoms[k][1] == acc:
+            acc *= atoms[k][0]
+        else:
+            break
+    return acc
+
+
+def _split_atoms_for_vec(atoms, vec_len):
+    """Returns outer atoms (the inner vec_len-element tail is consumed by one
+    vec ld/st and dropped). Splits the boundary atom if needed."""
+    outer = list(atoms)
+    acc = 1
+    while outer:
+        ext, ss, rm = outer[-1]
+        new_acc = acc * ext
+        if new_acc == vec_len:
+            outer.pop()
+            return outer
+        if new_acc > vec_len:
+            inner_factor = vec_len // acc
+            outer[-1] = (ext // inner_factor, ss * inner_factor, rm * inner_factor)
+            return outer
+        acc = new_acc
+        outer.pop()
+    raise ValueError(f"tail too short for vec_len {vec_len}")
+
+
+def _align_layouts(op_call: TilePrimitiveCall, sctx: DispatchContext):
+    op_call = TilePrimitiveCall.downcast(op_call)
+    src_br = op_call.src
+    dst_br = op_call.dst
+    if src_br.buffer.scope() == "local":
+        r_br, s_br = src_br, dst_br
+    else:
+        r_br, s_br = dst_br, src_br
+    r_buf = r_br.buffer
+    s_buf = s_br.buffer
+    r_region = [(r.min, r.min + r.extent) for r in r_br.region]
+    s_region = [(r.min, r.min + r.extent) for r in s_br.region]
+    # Push the dispatch target so layout.canonicalize() runs scope-aware
+    # fusers (e.g. laneid+wid_in_wg -> tid_in_wg).
+    with sctx.target:
+        return align_layouts_raw(
+            r_buf.layout,
+            r_buf.shape,
+            r_region,
+            s_buf.layout,
+            s_buf.shape,
+            s_region,
+        )
+
+
+def _make_thread_placeholders(r_p) -> dict[str, _TirVar]:
+    placeholders: dict[str, _TirVar] = {}
+    for it in r_p.shard:
+        name = it.axis.name
+        if it.axis.is_thread() and name not in placeholders:
+            placeholders[name] = _TirVar(name, "int32")
+    return placeholders
+
+
+def _s_thread_offset(r_p, s_p, placeholders: dict[str, _TirVar]):
+    """Per-thread S base offset. Coord per R position is placeholder (thread
+    axis) or 0 (memory axis); apply_to_shape decomposes across s_p iters.
+    Includes layout-level offsets (e.g. from slicing a non-zero S region)."""
+    coord = [
+        placeholders[it.axis.name] if it.axis.is_thread() else _IntImm("int32", 0)
+        for it in r_p.shard
+    ]
+    input_shape = [int(it.extent) for it in r_p.shard]
+    per_iter = s_p.apply_to_shape(coord, input_shape)
+    off = _IntImm("int32", 0)
+    for c, it in zip(per_iter, s_p.shard, strict=True):
+        off = off + c * it.stride
+    for _axis, val in s_p.offset.items():
+        off = off + val
+    return off
+
+
+_VEC_BITS_CANDIDATES = (128, 64, 32, 16, 8)
+
+
+def _vec_len_candidates(elem_bits: int) -> list[int]:
+    """Widest-first element counts to try; always ends with scalar (1)."""
+    out: list[int] = []
+    for vb in _VEC_BITS_CANDIDATES:
+        if vb < elem_bits or vb % elem_bits != 0:
+            continue
+        n = vb // elem_bits
+        if n not in out:
+            out.append(n)
+    if 1 not in out:
+        out.append(1)
+    return out
+
+
+def _choose_vec_len(elem_bits: int, atoms, r_p, s_p) -> int:
+    """Widest candidate that:
+      1. divides the atom contiguous-tail extent (so vec_len consecutive
+         R-side regs map to vec_len contiguous S-side elements), AND
+      2. keeps every per-thread / per-round address-offset term a
+         multiple of vec_len, so the resulting vec ld/st pointer is
+         naturally aligned to vec_bits/8 bytes.
+
+    Only **mem-axis** strides contribute to physical address. Thread-axis
+    iter strides live in partition-coord space (which thread owns which
+    logical position), not in the buffer's storage space — they're
+    redistributed through ``apply_to_shape`` into the mem iters and don't
+    appear directly in the per-thread address. So neither r-side nor
+    s-side thread-axis strides belong in the alignment check.
+
+    The contig-tail atoms (whose extents the vec ld/st consumes) have
+    stride 1 by definition; they live entirely inside the vec and
+    contribute nothing to the per-round address delta. Only the
+    **post-vec-split** outer atom strides matter for the per-round delta.
+    """
+    t = _atoms_contiguous_tail_extent(atoms)
+    # Region-base offsets are real address contributions. Thread-iter
+    # strides on either side are partition-virtual, not storage-physical,
+    # so they don't enter the per-thread address — exclude them.
+    shared_terms = list(s_p.offset.values()) + list(r_p.offset.values())
+    for n in _vec_len_candidates(elem_bits):
+        if n == 1:
+            return n
+        if t % n != 0 or t < n:
+            continue
+        # Post-vec-split outer atoms: these are the strides that contribute
+        # to per-round address deltas after the vec consumes the inner tail.
+        outer = _split_atoms_for_vec(atoms, n)
+        outer_atom_terms = [a[1] for a in outer] + [a[2] for a in outer]
+        if not _alignment_ok(n, outer_atom_terms + shared_terms):
+            continue
+        return n
+    return 1
+
+
+def _axis_decl(axis_name: str, sctx: DispatchContext):
+    """Declare the runtime Var for one thread axis (called inside impl body).
+
+    Each scope_id declarator emits a ``ScopeIdDef`` stmt at the current
+    builder frame. ``TilePrimitiveDispatch`` re-gathers + resolves all
+    ScopeIdDefs after dispatch (see ``ResolveAllScopeBinds`` in
+    ``tile_primitive_dispatch.cc``), so dispatch-introduced vars are bound
+    alongside kernel-declared ones.
+
+    Extents are deferred: the kernel header is expected to declare the full
+    scope-id chain (``cta_id`` / ``warpgroup_id`` / ``warp_id_in_wg`` /
+    ``lane_id`` / ``thread_id`` / ``thread_id_in_wg``) — the verifier then
+    fills our deferred defs from those siblings.
+    """
+    if axis_name == "tx":
+        return sctx.launch_params["threadIdx.x"].var
+    if axis_name == "laneid":
+        return T.lane_id()
+    if axis_name == "wid_in_wg":
+        return T.warp_id_in_wg()
+    if axis_name == "tid_in_wg":
+        return T.thread_id_in_wg()
+    if axis_name == "warpid":
+        return T.warp_id()
+    if axis_name == "wgid":
+        return T.warpgroup_id()
+    raise ValueError(f"unsupported thread axis {axis_name}")
+
+
+def _s_thread_offset_with_vars(r_p, s_p, axis_var_map: dict):
+    coord = [
+        axis_var_map[it.axis.name] if it.axis.is_thread() else _IntImm("int32", 0)
+        for it in r_p.shard
+    ]
+    input_shape = [int(it.extent) for it in r_p.shard]
+    per_iter = s_p.apply_to_shape(coord, input_shape)
+    off = _IntImm("int32", 0)
+    for c, it in zip(per_iter, s_p.shard, strict=True):
+        off = off + c * it.stride
+    for _ax, val in s_p.offset.items():
+        off = off + val
+    return off
+
+
+def _substitute_axes(s_off_template, placeholders: dict[str, _TirVar], sctx: DispatchContext):
+    """Inside an impl body: declare real scope_ids and rewrite the
+    placeholder-built ``s_off_template`` to use them."""
+    vmap = {placeholders[name]: _axis_decl(name, sctx) for name in placeholders}
+    return tvm.tirx.stmt_functor.substitute(s_off_template, vmap)
+
+
+def _flat_coords(outer_atoms, flat_idx: int) -> list[int]:
+    coords = []
+    rem = flat_idx
+    for a in reversed(outer_atoms):
+        coords.append(rem % a[0])
+        rem //= a[0]
+    coords.reverse()
+    return coords
+
+
+_POINTER_OFFSET_SRC = (
+    "\ntemplate <typename T>\n"
+    "__forceinline__ __device__ T* tvm_builtin_pointer_offset(T* ptr, int offset) {\n"
+    "    return ptr + offset;\n"
+    "}\n"
+)
+
+
+def _ptr_off(base_ptr, off):
+    return T.maca.func_call(
+        "tvm_builtin_pointer_offset",
+        base_ptr,
+        off,
+        source_code=_POINTER_OFFSET_SRC,
+        return_type="handle",
+    )
+
+
+def _outer_const_offsets(outer_atoms, flat_idx: int) -> tuple[int, int]:
+    """Returns (s_offset_const, r_offset_const) for one outer-loop flat index."""
+    coords = _flat_coords(outer_atoms, flat_idx)
+    ds = sum(c * a[1] for c, a in zip(coords, outer_atoms))
+    dr = sum(c * a[2] for c, a in zip(coords, outer_atoms))
+    return ds, dr
+
+
+def _emit_reg(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
+    op_call = TilePrimitiveCall.downcast(op_call)
+    src: Buffer = op_call.src.buffer
+    dst: Buffer = op_call.dst.buffer
+    if src.scope() == "local":
+        r_buf, s_buf, r_is_src = src, dst, True
+    else:
+        r_buf, s_buf, r_is_src = dst, src, False
+
+    with sctx.target:
+        r_p, s_p, s_seps = _align_layouts(op_call, sctx)
+    r_iters, s_groups = _split_thread_loop(r_p, s_p, s_seps)
+    atoms = _build_atoms(r_iters, s_groups)
+    elem_bits = DataType(src.dtype).bits
+    vec_len = _choose_vec_len(elem_bits, atoms, r_p, s_p)
+    vec_bits = vec_len * elem_bits
+    outer = _split_atoms_for_vec(atoms, vec_len)
+    per_thread_r_total = 1
+    for it in r_iters:
+        per_thread_r_total *= int(it.extent)
+    per_thread_r_shape = [per_thread_r_total or 1]
+
+    # Build the per-thread S offset OUTSIDE the impl using placeholder Vars
+    # (one per thread axis). Inside the impl we'll declare the real scope_ids
+    # via T.lane_id/T.thread_id_in_wg/... and substitute them in.
+    placeholders = _make_thread_placeholders(r_p)
+    s_off_template = _s_thread_offset(r_p, s_p, placeholders)
+
+    # R-side base offset from slicing (e.g. ``R[i*8:i*8+8]`` ⇒ ``i*8``). The
+    # canonicalize() result lives in ``r_p.offset``; sum across axes (memory
+    # or thread — irrelevant once it's all on R's local stride-1 storage).
+    r_off_base = _IntImm("int32", 0)
+    for _ax, val in r_p.offset.items():
+        r_off_base = r_off_base + val
+
+    copy_op = getattr(T.maca, f"copy_{vec_bits}b")
+
+    total_outer = 1
+    for a in outer:
+        total_outer *= a[0]
+
+    # Swizzle handling: recognize the iter-pattern on S side from the atom
+    # extents/strides (atom = (extent, s_stride, r_mul); a[1] is the S-side
+    # stride per outer round, equivalent to outer_iter strides in gmem_smem).
+    swizzle = get_swizzle(s_buf.layout)
+    swizzle_pattern = None
+    if swizzle is not None:
+        swizzle_pattern = try_recognize(
+            swizzle,
+            [a[0] for a in outer],
+            [a[1] for a in outer],
+            s_off_template,
+        )
+
+    class _SwizzleState:
+        def __init__(self):
+            self.signed_strides = None
+            self.base_off = None
+
+    state = _SwizzleState()
+
+    def _setup_swizzle(s_off):
+        if swizzle_pattern is None:
+            return
+        state.signed_strides, state.base_off = emit_init(swizzle_pattern, s_off)
+
+    def _s_iter_off(f, ds, s_off):
+        if swizzle_pattern is not None:
+            return emit_iter_offset(swizzle_pattern, state.signed_strides, state.base_off, f)
+        if swizzle is not None:
+            return emit_fallback_offset(swizzle, s_off, ds)
+        return s_off + ds
+
+    # fmt: off
+    s_zero_indices = [0] * len(s_buf.shape)
+
+    @T.prim_func(check_well_formed=False)
+    def impl():
+        s_off = _substitute_axes(s_off_template, placeholders, sctx)
+        _setup_swizzle(s_off)
+        r_local = r_buf.local(*per_thread_r_shape)
+        # Keep as a serial TIR loop and let ptxas unroll downstream. An
+        # explicit ``T.unroll`` materializes the per-iter scratch
+        # (ds/dr/s_ptr/r_ptr, swizzle ``v_<n>[]`` signed-strides) as N
+        # copies of each buffer declaration; on kernels with many R↔S copy
+        # sites and large ``total_outer`` (FA4 writeback) this floods the
+        # function with ``alignas(64) int`` arrays and pressures registers.
+        for f in range(total_outer):
+            ds, dr = _outer_const_offsets(outer, f)
+            s_ptr = _ptr_off(s_buf.ptr_to(s_zero_indices), _s_iter_off(f, ds, s_off))
+            r_ptr = _ptr_off(r_local.ptr_to([0]), r_off_base + dr)
+            if r_is_src:
+                copy_op(s_ptr, r_ptr)
+            else:
+                copy_op(r_ptr, s_ptr)
+    # fmt: on
+    import os
+
+    if os.environ.get("R2S_DUMP"):
+        print("=== emitted impl ===")
+        print(impl.script())
+    return impl
+
+
+@register_dispatch(
+    "copy",
+    "maca",
+    variant="reg",
+    priority=10,
+    when=[predicate("reg_applicable", _is_reg_copy)],
+)
+def copy_schedule_reg(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc:
+    return _emit_reg(op_call, sctx)

--- a/python/tvm/backend/maca/operator/tile_primitive/copy/utils.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/copy/utils.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Shared helpers for copy operator dispatches on MACA targets."""
+
+from collections.abc import Iterable
+
+from tvm.tirx.operator.tile_primitive.registry import DispatchContext
+from tvm.tirx.stmt import TilePrimitiveCall
+
+from ..common import match_scope, validate_copy_op
+
+
+def _single_thread_exec(op_call: TilePrimitiveCall, sctx: DispatchContext):
+    """Predicate: exec scope must be single-thread."""
+    exec_scope = sctx.scope_kind
+    ok = exec_scope == "thread"
+    return (ok, None if ok else f"expected thread exec_scope, got {exec_scope}")
+
+
+DEFAULT_ALLOWED_PAIRS: tuple[tuple[str, str], ...] = (
+    ("global", "shared*"),
+    ("shared*", "global"),
+    ("global", "local"),
+    ("local", "global"),
+    ("shared*", "local"),
+    ("local", "shared*"),
+)
+
+
+def _scope_allowed(
+    op_call: TilePrimitiveCall,
+    sctx: DispatchContext,
+    allowed_pairs: Iterable[tuple[str, str]] = DEFAULT_ALLOWED_PAIRS,
+):
+    op_call = TilePrimitiveCall.downcast(op_call)
+    dst_buffer_region, src_buffer_region = (op_call.dst, op_call.src)
+    src_scope = src_buffer_region.buffer.scope()
+    dst_scope = dst_buffer_region.buffer.scope()
+    ok = any(
+        (
+            match_scope(src_scope, src_pat) and match_scope(dst_scope, dst_pat)
+            for src_pat, dst_pat in allowed_pairs
+        )
+    )
+    if not ok:
+        allowed_str = ", ".join((f"{a}->{b}" for a, b in allowed_pairs))
+        return (
+            False,
+            f"unsupported memory scopes src={src_scope} dst={dst_scope}; allowed: {allowed_str}",
+        )
+    return (True, None)
+
+
+def _is_valid_copy(op_call: TilePrimitiveCall, sctx: DispatchContext):
+    return (validate_copy_op(op_call, sctx), "validate_copy_op failed")

--- a/python/tvm/backend/maca/script.py
+++ b/python/tvm/backend/maca/script.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""MACA TVMScript namespaces."""
+
+from __future__ import annotations
+
+from tvm.backend.maca import op as _maca_op
+from tvm.tirx.script.builder.ir import _op_wrapper
+
+# pylint: disable=protected-access
+
+
+class MACANamespace:
+    """The MACA intrinsics submodule."""
+
+    def __init__(self):
+        self.func_call = _op_wrapper(_maca_op.maca_func_call)
+        self.thread_fence = _op_wrapper(_maca_op.maca_thread_fence)
+        self.warp_sync = _op_wrapper(_maca_op.maca_warp_sync)
+        self.cta_sync = _op_wrapper(_maca_op.maca_cta_sync)
+        self.copy_bytes = _op_wrapper(_maca_op.maca_copy_bytes)
+        self.copy_128b = _op_wrapper(_maca_op.maca_copy_128b)
+        self.copy_64b = _op_wrapper(_maca_op.maca_copy_64b)
+        self.copy_32b = _op_wrapper(_maca_op.maca_copy_32b)
+        self.copy_16b = _op_wrapper(_maca_op.maca_copy_16b)
+        self.copy_8b = _op_wrapper(_maca_op.maca_copy_8b)
+
+
+__all__ = ["MACANamespace"]

--- a/python/tvm/relax/frontend/nn/extern.py
+++ b/python/tvm/relax/frontend/nn/extern.py
@@ -371,6 +371,14 @@ class SourceModule(ExternModule):  # pylint: disable=too-few-public-methods
                 # Enable `-fPIC` for the host compiler
                 "-Xcompiler=-fPIC",
             ]
+        elif source_format == "maca":
+            host_flags = [
+                "-c",  # generate object file
+                "-O3",
+                "-std=c++17",
+                # Enable `-fPIC` for the host compiler
+                "-Xcompiler=-fPIC",
+            ]
         else:
             raise ValueError(f"Invalid source format: {source_format}")
         return include_flags + host_flags

--- a/python/tvm/target/detect_target.py
+++ b/python/tvm/target/detect_target.py
@@ -41,24 +41,8 @@ def _detect_cpu(dev: Device) -> Target:  # pylint: disable=unused-argument
     )
 
 
-def _detect_maca(dev: Device) -> Target:
-    """Detect the current MACA device architecture."""
-    return Target(
-        {
-            "kind": "maca",
-            "max_num_threads": 1024,
-            "max_shared_memory_per_block": dev.max_shared_memory_per_block,
-            "max_threads_per_block": dev.max_threads_per_block,
-            "mcpu": "xcore1000",
-            "mtriple": "mxc-metax-macahca",
-            "thread_warp_size": dev.warp_size,
-        }
-    )
-
-
 SUPPORTED_DEVICE: dict[str, Callable[[Device], Target]] = {
     "cpu": _detect_cpu,
-    "maca": _detect_maca,
 }
 
 # Backward-compatible alias for the previous private module-level map.

--- a/python/tvm/tirx/exec_context.py
+++ b/python/tvm/tirx/exec_context.py
@@ -193,7 +193,7 @@ class LaneBinding:
     declared_extent: int
 
 
-def initial_A(*, lane_ext: int = 32, warp_ext: int, cta_ext: int = 1) -> ActiveSet:
+def initial_A(*, lane_ext: int = 64, warp_ext: int, cta_ext: int = 1) -> ActiveSet:
     """Build A at PrimFunc device entry: all threads active, offsets all zero."""
     return ActiveSet.from_axes(
         [
@@ -313,9 +313,9 @@ def _factor_warpid(warp: AxisRange) -> tuple[AxisRange, AxisRange] | None:
 def _flat_product_range(
     major: AxisRange, lane: AxisRange, lo: int, hi: int
 ) -> tuple[AxisRange, AxisRange]:
-    active_min = major.offset * 32 + lane.offset
+    active_min = major.offset * 64 + lane.offset
     active_max = (
-        (major.offset + major.stride * (major.extent - 1)) * 32
+        (major.offset + major.stride * (major.extent - 1)) * 64
         + lane.offset
         + lane.stride * (lane.extent - 1)
         + 1
@@ -328,19 +328,19 @@ def _flat_product_range(
 
     lane_hi = lane.offset + lane.extent
     major_hi = major.offset + major.extent
-    hit_lo = max(major.offset, (lo - lane_hi) // 32 + 1)
-    hit_hi = min(major_hi, _ceildiv(hi - lane.offset, 32))
+    hit_lo = max(major.offset, (lo - lane_hi) // 64 + 1)
+    hit_hi = min(major_hi, _ceildiv(hi - lane.offset, 64))
     if hit_hi <= hit_lo:
         raise ExecContextError("flat thread range produces empty active set")
 
     if hit_hi == hit_lo + 1:
-        new_lane_lo = max(lane.offset, lo - hit_lo * 32)
-        new_lane_hi = min(lane_hi, hi - hit_lo * 32)
+        new_lane_lo = max(lane.offset, lo - hit_lo * 64)
+        new_lane_hi = min(lane_hi, hi - hit_lo * 64)
         if new_lane_hi <= new_lane_lo:
             raise ExecContextError("flat thread range produces empty lane range")
         return AxisRange(1, hit_lo), AxisRange(new_lane_hi - new_lane_lo, new_lane_lo)
 
-    if lo <= hit_lo * 32 + lane.offset and (hit_hi - 1) * 32 + lane_hi <= hi:
+    if lo <= hit_lo * 64 + lane.offset and (hit_hi - 1) * 64 + lane_hi <= hi:
         return AxisRange(hit_hi - hit_lo, hit_lo), lane
 
     raise ExecContextError("flat thread range would require a non-rectangular lane/warp active set")

--- a/src/backend/maca/codegen/codegen_maca.cc
+++ b/src/backend/maca/codegen/codegen_maca.cc
@@ -481,6 +481,10 @@ std::string CodeGenMACA::Finish() {
   decl_stream << "\n#ifndef b16vectype\n";
   decl_stream << "  typedef __NATIVE_VECTOR__(1, short) b16vectype;\n";
   decl_stream << "#endif\n";
+  // Generate util functions
+  for (const auto& [name, code] : util_funcs_) {
+    decl_stream << code;
+  }
   return CodeGenC::Finish();
 }
 
@@ -979,6 +983,16 @@ std::string CodeGenMACA::CastFromTo(std::string value, const PrimType& from,
   return os.str();
 }
 
+void CodeGenMACA::AddUtilFunction(const std::string& func_name, const std::string& code) {
+  auto it = this->util_funcs_.find(func_name);
+  if (it != this->util_funcs_.end()) {
+    TVM_FFI_ICHECK_EQ(it->second, code)
+        << "Function " << func_name << " already exists with different code";
+    return;
+  }
+  this->util_funcs_.insert({func_name, code});
+}
+
 void CodeGenMACA::VisitExpr_(const CastNode* op, std::ostream& os) {
   PrimType from_ty = op->value.ty();
   PrimType target_ty = op->ty();
@@ -1077,11 +1091,52 @@ void CodeGenMACA::PrintCallExtern(Type ret_type, ffi::String global_symbol,
   }
 }
 void CodeGenMACA::VisitExpr_(const CallNode* op, std::ostream& os) {
+  auto print_maca_func_call = [&](const CallNode* op, std::ostream& os) {
+    TVM_FFI_ICHECK_GE(op->args.size(), 2U);
+    size_t num_args = op->args.size() - 2;
+    std::vector<std::string> args;
+    for (size_t i = 1; i < num_args + 1; i++) {
+      args.push_back(this->PrintExpr(op->args[i]));
+    }
+    std::string source_code = op->args[num_args + 1].as<StringImmNode>()->value;
+    std::string func_name = op->args[0].as<StringImmNode>()->value;
+    os << func_name << "(";
+    for (size_t i = 0; i < num_args; i++) {
+      const auto& arg = args[i];
+      os << arg;
+      if (i < num_args - 1) {
+        os << ", ";
+      }
+    }
+    os << ")";
+    AddUtilFunction(func_name, source_code);
+  };
+
+  if (auto opt_call_opt = op->op.as<Op>()) {
+    Op call_op = opt_call_opt.value();
+    auto codegen_getter = tvm::ffi::Function::GetGlobal("tirx.intrinsics.maca.get_codegen");
+    TVM_FFI_ICHECK(codegen_getter.has_value())
+        << "tirx.intrinsics.maca.get_codegen is not registered";
+    // either codegen is registered or not
+    auto codegen = codegen_getter.value()(call_op->name).cast<ffi::Optional<tvm::ffi::Function>>();
+    if (codegen.has_value()) {
+      // codegen is registered, it should return a Call to maca_func_call
+      auto func_call = codegen.value()(op->args);
+      auto res = func_call.cast<ffi::Tuple<Call, ffi::Array<ffi::String>>>();
+      print_maca_func_call(res.get<0>().get(), os);
+      // for (const auto& tag : res.get<1>()) {
+      //   codegen_tags_.insert(tag.operator std::string());
+      // }
+      return;
+    }
+  }
   static const Op& tvm_fill_fragment_op = Op::Get("tirx.tvm_fill_fragment");
   static const Op& tvm_load_matrix_sync_op = Op::Get("tirx.tvm_load_matrix_sync");
   static const Op& tvm_store_matrix_sync_op = Op::Get("tirx.tvm_store_matrix_sync");
   static const Op& tvm_mma_sync_op = Op::Get("tirx.tvm_mma_sync");
   static const Op& tvm_bmma_sync_op = Op::Get("tirx.tvm_bmma_sync");
+  static const Op& maca_func_call_op = Op::Get("tirx.maca.func_call");
+
   if (auto opt_call_opt = op->op.as<Op>()) {
     Op call_op = opt_call_opt.value();
     // This is only for backward compatibility with __shfl_{up/down}.
@@ -1150,6 +1205,9 @@ void CodeGenMACA::VisitExpr_(const CallNode* op, std::ostream& os) {
       this->PrintExpr(op->args[i * 2 + 1], os);
       os << "]" << ((i < 3) ? ", " : ")");
     }
+  } else if (op->op.same_as(maca_func_call_op) ||
+             (op->op.as<Op>() && op->op.as<Op>().value()->name == "tirx.maca.func_call")) {
+    print_maca_func_call(op, os);
   } else {
     CodeGenC::VisitExpr_(op, os);
   }
@@ -1251,7 +1309,7 @@ void CodeGenMACA::VisitStmt_(const AllocBufferNode* op) {
       }
     } else {
       if (align > 0) {
-        stream << "alignas(" << align << ") ";
+        stream << "__attribute__((aligned(" << align << "))) ";
       }
       PrintType(dtype, stream);
     }

--- a/src/backend/maca/codegen/codegen_maca.h
+++ b/src/backend/maca/codegen/codegen_maca.h
@@ -95,6 +95,7 @@ class CodeGenMACA final : public CodeGenC {
   void PrintVecElemLoadExpr(const PrimType& t, int i, const std::string& value,
                             std::ostream& os) final;
   std::string CastFromTo(std::string value, const PrimType& from, const PrimType& target) final;
+  void AddUtilFunction(const std::string& name, const std::string& code);
   // overload visitor
   void VisitExpr_(const RampNode* op, std::ostream& os) final;       // NOLINT(*)
   void VisitExpr_(const SelectNode* op, std::ostream& os) final;     // NOLINT(*)
@@ -151,6 +152,8 @@ class CodeGenMACA final : public CodeGenC {
   // The alignment of the barrier array in shared memory
   // Set to 16 to maintain minimum alignment requirements for async bulk copy
   const int barrier_alignment_bytes_ = 16;
+  // Functions to be added to the util functions during codegen
+  std::unordered_map<std::string, std::string> util_funcs_;
 
   std::unordered_map<const VarNode*, std::string> fragment_shapes;
   std::unordered_map<const VarNode*, std::string> fragment_layouts;

--- a/src/backend/maca/op/target_builtin.cc
+++ b/src/backend/maca/op/target_builtin.cc
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file backend/maca/op/target_builtin.cc
+ *
+ *  builtin intrinsic operators specific to MACA target.
+ */
+#include <tvm/ffi/function.h>
+#include <tvm/runtime/base.h>
+#include <tvm/tirx/builtin.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/op_attr_types.h>
+
+#include <string>
+
+namespace tvm {
+namespace tirx {
+namespace builtin {
+
+#define TIRX_DEFINE_BUILTIN_FUNC(OpName)                                           \
+  OpRegEntry::RegisterOrGet("tirx." #OpName)                                       \
+      .set_name()                                                                  \
+      .set_attr<TScriptPrinterName>("TScriptPrinterName", ffi::String(#OpName), 1) \
+      .set_attr<TIRxOpCategory>("TIRxOpCategory", ffi::String("builtin"), /*plevel=*/1)
+
+namespace {
+void RegisterDeviceIntrinsicAliases();
+}
+
+void RegisterMACATargetBuiltins() {
+  // clang-format off
+static bool registered = false;
+if (registered) return;
+registered = true;
+
+RegisterDeviceIntrinsicAliases();
+  // clang-format on
+}
+
+namespace {
+
+struct DeviceIntrinsicRegistration {
+  const char* name;
+  const char* namespace_name;
+  CallEffectKind effect_kind;
+};
+
+void RegisterDeviceIntrinsic(const DeviceIntrinsicRegistration& reg) {
+  std::string name(reg.name);
+  std::string namespace_name(reg.namespace_name);
+  std::string prefix = namespace_name + "_";
+  std::string suffix = name;
+  if (suffix.rfind(prefix, 0) == 0) {
+    suffix = suffix.substr(prefix.size());
+  }
+
+  std::string canonical_op_name = "tirx." + namespace_name + "." + suffix;
+  ffi::String namespace_attr(namespace_name);
+  ffi::String printer_name(namespace_name + "." + suffix);
+  int64_t effect = static_cast<int64_t>(reg.effect_kind);
+
+  auto register_one = [&](const std::string& op_name) {
+    OpRegEntry::RegisterOrGet(op_name)
+        .set_name()
+        .set_attr<TIRxOpCategory>("TIRxOpCategory", ffi::String("device_intrin"),
+                                  /*plevel=*/15)
+        .set_attr<TDeviceIntrinsicNamespace>("TDeviceIntrinsicNamespace", namespace_attr,
+                                             /*plevel=*/15)
+        .set_attr<TCallEffectKind>("TCallEffectKind", effect, /*plevel=*/15)
+        .set_attr<TScriptPrinterName>("TScriptPrinterName", printer_name, /*plevel=*/15);
+  };
+
+  register_one(canonical_op_name);
+}
+
+#define TIRX_DEVICE_INTRIN_ALIAS(OpName, Namespace, EffectKind) \
+  {#OpName, #Namespace, CallEffectKind::EffectKind}
+
+const DeviceIntrinsicRegistration kDeviceIntrinsics[] = {
+    TIRX_DEVICE_INTRIN_ALIAS(maca_func_call, maca, kOpaque),
+    TIRX_DEVICE_INTRIN_ALIAS(maca_cta_sync, maca, kOpaque),
+    TIRX_DEVICE_INTRIN_ALIAS(maca_copy_bytes, maca, kOpaque),
+};
+
+void RegisterDeviceIntrinsicAliases() {
+  for (const auto& reg : kDeviceIntrinsics) {
+    RegisterDeviceIntrinsic(reg);
+  }
+}
+
+#undef TIRX_DEVICE_INTRIN_ALIAS
+
+}  // namespace
+
+#undef TIRX_DEFINE_BUILTIN_FUNC
+
+TVM_FFI_STATIC_INIT_BLOCK() { RegisterMACATargetBuiltins(); }
+
+}  // namespace builtin
+}  // namespace tirx
+}  // namespace tvm

--- a/src/tirx/analysis/exec_context.cc
+++ b/src/tirx/analysis/exec_context.cc
@@ -37,7 +37,7 @@ namespace tirx {
 
 namespace {
 
-constexpr int kWarpSize = 32;
+constexpr int kWarpSize = 64;
 
 PrimExpr I64(int64_t value) { return IntImm::Int64(value); }
 

--- a/src/tirx/ir/exec_scope.cc
+++ b/src/tirx/ir/exec_scope.cc
@@ -23,6 +23,7 @@
 #include <tvm/tirx/exec_scope.h>
 #include <tvm/tirx/op.h>
 
+#include <limits>
 #include <queue>
 
 namespace tvm {
@@ -425,6 +426,27 @@ ffi::Array<PrimExpr> ResolveCuda(ScopeBinding binding,
   }
   LOG(FATAL) << "Internal Error: unknown ScopeBinding " << static_cast<int>(binding);
 }
+
+ffi::Array<PrimExpr> ResolveMACA(ScopeBinding binding,
+                                 const ffi::Optional<ffi::Array<PrimExpr>>& extents, int out_dim,
+                                 const LaunchParams& params) {
+  arith::Analyzer ana;
+  switch (binding) {
+    case ScopeBinding::kKernelCta:
+      return Trivial3DResolve(params, "blockIdx.", out_dim);
+    case ScopeBinding::kCtaThread:
+      return Trivial3DResolve(params, "threadIdx.", out_dim);
+    case ScopeBinding::kCtaWarp: {
+      TVM_FFI_ICHECK_EQ(out_dim, 1) << "ValueError: cta->warp must be 1D";
+      return {ana->Simplify(GetThread("warp_id_in_cta", params).first)};
+    }
+    case ScopeBinding::kWarpThread: {
+      TVM_FFI_ICHECK_EQ(out_dim, 1) << "ValueError: warp->thread must be 1D";
+      return {ana->Simplify(FloorMod(GetLinearThreadIndex(params), 64))};
+    }
+  }
+  LOG(FATAL) << "Internal Error: unknown ScopeBinding " << static_cast<int>(binding);
+}
 }  // namespace
 
 ffi::Array<PrimExpr> ScopeIdResolve::Resolve(ScopeBinding binding,
@@ -432,15 +454,16 @@ ffi::Array<PrimExpr> ScopeIdResolve::Resolve(ScopeBinding binding,
                                              int out_dim, const ffi::String& target_kind,
                                              const LaunchParams& params) {
   if (target_kind == "cuda") return ResolveCuda(binding, extents, out_dim, params);
+  if (target_kind == "maca") return ResolveMACA(binding, extents, out_dim, params);
   LOG(FATAL) << "Cannot resolve ScopeIdDef for target=" << target_kind
              << " binding=" << static_cast<int>(binding);
 }
 
 PrimExpr ScopeIdResolve::ComputeWarpIdInCta(const LaunchParams& params) {
-  PrimExpr warp_id = FloorDiv(GetLinearThreadIndex(params), 32);
-  PrimExpr mask = IntImm(PrimType::UInt(32), 0xffffffff);
+  PrimExpr warp_id = FloorDiv(GetLinearThreadIndex(params), 64);
+  PrimExpr mask = MakeConst(PrimType::UInt(64), std::numeric_limits<uint64_t>::max());
   return Call(warp_id.ty(), builtin::tvm_warp_shuffle(),
-              {mask, warp_id, IntImm::Int32(0), IntImm::Int32(32), IntImm::Int32(32)});
+              {mask, warp_id, IntImm::Int32(0), IntImm::Int32(64), IntImm::Int32(64)});
 }
 
 }  // namespace tirx

--- a/src/tirx/transform/tile_primitive_dispatch.cc
+++ b/src/tirx/transform/tile_primitive_dispatch.cc
@@ -755,7 +755,7 @@ class TilePrimitiveDispatcher : public StmtExprMutator {
       LOG(WARNING) << "ExecContext tracking disabled: missing/symbolic threadIdx extents";
       return false;
     }
-    int64_t warp_ext = thread_ext / 32;
+    int64_t warp_ext = thread_ext / 64;
     auto cluster_cta_axes = collect_extents(
         {{"clusterCtaIdx.x", "cbx"}, {"clusterCtaIdx.y", "cby"}, {"clusterCtaIdx.z", "cbz"}});
     cluster_cta_axis_extents_ = cluster_cta_axes;
@@ -772,7 +772,7 @@ class TilePrimitiveDispatcher : public StmtExprMutator {
     // Preserve the old flattened cta_id split for 0-D/1-D declarations. Multi-dimensional
     // CTA ids keep their concrete factor axes (bx/by/bz or cbx/cby/cbz).
     if (cta_axes.size() <= 1) cta_axes.clear();
-    ctx_stack_.push_back(ExecContext::AtKernelEntry(/*lane_ext=*/32, warp_ext, cta_ext, cta_axes));
+    ctx_stack_.push_back(ExecContext::AtKernelEntry(/*lane_ext=*/64, warp_ext, cta_ext, cta_axes));
     return true;
   }
 

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_fallback.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_fallback.py
@@ -57,10 +57,10 @@ def _round_trip_shapes_and_threads():
     variants can't accept it (size doesn't divide thread_cnt).
     """
     return [
-        # warp scope, 32 threads, 24 elements (4x6) → 24 % 32 != 0.
-        ("warp", 32, (4, 6), "4*6=24 ∤ 32"),
-        # warp scope, 32 threads, 8 elements (1x8) → 8 % 32 != 0.
-        ("warp", 32, (1, 8), "1*8=8 ∤ 32"),
+        # warp scope, 64 threads, 24 elements (4x6) → 24 % 32 != 0.
+        ("warp", 64, (4, 6), "4*6=24 ∤ 32"),
+        # warp scope, 64 threads, 8 elements (1x8) → 8 % 32 != 0.
+        ("warp", 64, (1, 8), "1*8=8 ∤ 32"),
         # warpgroup scope, 128 threads, 24 elements (4x6) → 24 % 128 != 0.
         ("warpgroup", 128, (4, 6), "4*6=24 ∤ 128"),
         # warpgroup scope, 128 threads, 32 elements (4x8) → 32 % 128 != 0.
@@ -90,11 +90,11 @@ def _build_round_trip_kernel(scope, n_threads, shape, dtype):
             B = T.match_buffer(B_ptr, shape, dtype)
             T.device_entry()
             T.cta_id([1])
-            T.lane_id([32])
+            T.lane_id([64])
             T.thread_id([n_threads])
             A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
             Tx.warp.copy(A_smem[full], A[full])
-            T.cuda.cta_sync()
+            T.maca.cta_sync()
             Tx.warp.copy(B[full], A_smem[full])
 
     elif scope == "warpgroup":
@@ -123,12 +123,12 @@ def _build_round_trip_kernel(scope, n_threads, shape, dtype):
             B = T.match_buffer(B_ptr, shape, dtype)
             T.device_entry()
             T.cta_id([1])
-            T.warp_id([n_threads // 32])
-            T.lane_id([32])
+            T.warp_id([n_threads // 64])
+            T.lane_id([64])
             T.thread_id([n_threads])
             A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
             Tx.cta.copy(A_smem[full], A[full])
-            T.cuda.cta_sync()
+            T.maca.cta_sync()
             Tx.cta.copy(B[full], A_smem[full])
 
     else:
@@ -139,11 +139,21 @@ def _build_round_trip_kernel(scope, n_threads, shape, dtype):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 @pytest.mark.parametrize(
     "scope,n_threads,shape,why",
     [
-        pytest.param(s, n, sh, w, id=f"{s}-{n}-{'x'.join(map(str, sh))}")
+        pytest.param(
+            s,
+            n,
+            sh,
+            w,
+            id=f"{s}-{n}-{'x'.join(map(str, sh))}",
+            marks=pytest.mark.xfail(
+                reason="TODO(maca): [tile-primitive-copy-fallback] support warpgroup"
+            )
+            if s == "warpgroup"
+            else (),
+        )
         for s, n, sh, w in _round_trip_shapes_and_threads()
     ],
 )
@@ -172,7 +182,6 @@ def test_fallback_round_trip(scope, n_threads, shape, why):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 def test_fallback_thread_scope():
     """``T.thread()`` — single thread, no gate. Either ``gmem_smem`` picks
     it up (n_elements % 1 == 0) or ``fallback`` does — both end up emitting
@@ -192,7 +201,7 @@ def test_fallback_thread_scope():
         T.thread_id([1])
         A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
         Tx.copy(A_smem[full], A[full])
-        T.cuda.cta_sync()
+        T.maca.cta_sync()
         Tx.copy(B[full], A_smem[full])
 
     dev = tvm.maca(0)
@@ -210,9 +219,8 @@ def test_fallback_thread_scope():
     np.testing.assert_array_equal(B.numpy(), A_np)
 
 
-@MACA_XFAIL
 def test_fallback_emits_gate():
-    """Compiled CUDA source must contain a single-thread gate so only one
+    """Compiled MACA source must contain a single-thread gate so only one
     active thread executes the scalar copy (not all of them, which would
     work but be racy + wasteful and indicate gate elision)."""
     shape = (4, 6)

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_gmem_smem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_gmem_smem.py
@@ -59,7 +59,7 @@ def _build_kernel(scope, n_threads, shape, dtype):
             T.thread_id([n_threads])
             A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
             Tx.wg.copy(A_smem[full_slices], A[full_slices])
-            T.cuda.cta_sync()
+            T.maca.cta_sync()
             Tx.wg.copy(B[full_slices], A_smem[full_slices])
 
     elif scope == "warp":
@@ -74,7 +74,7 @@ def _build_kernel(scope, n_threads, shape, dtype):
             T.thread_id([n_threads])
             A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
             Tx.warp.copy(A_smem[full_slices], A[full_slices])
-            T.cuda.cta_sync()
+            T.maca.cta_sync()
             Tx.warp.copy(B[full_slices], A_smem[full_slices])
 
     elif scope == "cta":
@@ -90,7 +90,7 @@ def _build_kernel(scope, n_threads, shape, dtype):
             T.thread_id([n_threads])
             A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
             Tx.cta.copy(A_smem[full_slices], A[full_slices])
-            T.cuda.cta_sync()
+            T.maca.cta_sync()
             Tx.cta.copy(B[full_slices], A_smem[full_slices])
     else:
         raise ValueError(f"unsupported scope {scope!r}")
@@ -234,7 +234,7 @@ def test_copy_g2s_s2g(task, dtype, scope):
         # `scope` is parametrized at runtime; select the scope namespace
         # dynamically (T.cta / T.thread) instead of a literal prefix.
         getattr(Tx, scope).copy(A_smem[r_smem], A[r_gmem])
-        T.cuda.cta_sync()
+        T.maca.cta_sync()
         getattr(Tx, scope).copy(B[r_gmem], A_smem[r_smem])
 
     np_dtype = tvm.testing.np_dtype_from_str(dtype)
@@ -549,7 +549,7 @@ def test_gmem_smem_swizzle_fast_path_fires_with_var_bounds():
         T.thread_id([32])
         smem = T.alloc_buffer(shape, "float16", scope="shared", layout=s_layout)
         Tx.warp.copy(smem, A[:, :])
-        T.cuda.cta_sync()
+        T.maca.cta_sync()
         Tx.warp.copy(B[:, :], smem)
 
     target = tvm.target.Target("maca")

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
@@ -106,19 +106,19 @@ def _build_roundtrip_kernel(scope, n_threads, k, dtype, non_r_scope):
                 B = T.match_buffer(B_ptr, shape, dtype)
                 T.device_entry()
                 T.cta_id([1])
-                T.lane_id([32])
+                T.lane_id([64])
                 tid = T.thread_id([n_threads])
                 A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
                 for kk in range(k):
                     A_smem[tid, kk] = T.cast(tid * 100 + kk + 1, dtype)
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 R_local = T.alloc_buffer(shape, dtype, scope="local", layout=r_layout)
                 Tx.warp.copy(R_local[full_slices], A_smem[full_slices])
                 for kk in range(k):
                     A_smem[tid, kk] = T.cast(0, dtype)
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 Tx.warp.copy(A_smem[full_slices], R_local[full_slices])
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 for kk in range(k):
                     B[tid, kk] = A_smem[tid, kk]
 
@@ -129,20 +129,20 @@ def _build_roundtrip_kernel(scope, n_threads, k, dtype, non_r_scope):
                 B = T.match_buffer(B_ptr, shape, dtype)
                 T.device_entry()
                 T.cta_id([1])
-                T.warp_id([n_threads // 32])
-                T.lane_id([32])
+                T.warp_id([n_threads // 64])
+                T.lane_id([64])
                 tid = T.thread_id([n_threads])
                 A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
                 for kk in range(k):
                     A_smem[tid, kk] = T.cast(tid * 100 + kk + 1, dtype)
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 R_local = T.alloc_buffer(shape, dtype, scope="local", layout=r_layout)
                 Tx.cta.copy(R_local[full_slices], A_smem[full_slices])
                 for kk in range(k):
                     A_smem[tid, kk] = T.cast(0, dtype)
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 Tx.cta.copy(A_smem[full_slices], R_local[full_slices])
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 for kk in range(k):
                     B[tid, kk] = A_smem[tid, kk]
 
@@ -183,18 +183,18 @@ def _build_roundtrip_kernel(scope, n_threads, k, dtype, non_r_scope):
                 B = T.match_buffer(B_ptr, shape, dtype)
                 T.device_entry()
                 T.cta_id([1])
-                T.lane_id([32])
+                T.lane_id([64])
                 tid = T.thread_id([n_threads])
                 for kk in range(k):
                     A[tid, kk] = T.cast(tid * 100 + kk + 1, dtype)
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 R_local = T.alloc_buffer(shape, dtype, scope="local", layout=r_layout)
                 Tx.warp.copy(R_local[full_slices], A[full_slices])
                 for kk in range(k):
                     A[tid, kk] = T.cast(0, dtype)
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 Tx.warp.copy(A[full_slices], R_local[full_slices])
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 for kk in range(k):
                     B[tid, kk] = A[tid, kk]
 
@@ -206,19 +206,19 @@ def _build_roundtrip_kernel(scope, n_threads, k, dtype, non_r_scope):
                 B = T.match_buffer(B_ptr, shape, dtype)
                 T.device_entry()
                 T.cta_id([1])
-                T.warp_id([n_threads // 32])
-                T.lane_id([32])
+                T.warp_id([n_threads // 64])
+                T.lane_id([64])
                 tid = T.thread_id([n_threads])
                 for kk in range(k):
                     A[tid, kk] = T.cast(tid * 100 + kk + 1, dtype)
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 R_local = T.alloc_buffer(shape, dtype, scope="local", layout=r_layout)
                 Tx.cta.copy(R_local[full_slices], A[full_slices])
                 for kk in range(k):
                     A[tid, kk] = T.cast(0, dtype)
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 Tx.cta.copy(A[full_slices], R_local[full_slices])
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 for kk in range(k):
                     B[tid, kk] = A[tid, kk]
 
@@ -239,16 +239,36 @@ def _expected(shape, dtype):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 @pytest.mark.parametrize("non_r_scope", ["shared", "global"])
 @pytest.mark.parametrize(
     "scope,n_threads,k",
     [
-        ("warpgroup", 128, 16),
-        ("warpgroup", 128, 32),
-        ("warpgroup", 128, 8),
-        ("warp", 32, 8),
-        ("warp", 32, 16),
+        pytest.param(
+            "warpgroup",
+            128,
+            16,
+            marks=pytest.mark.xfail(
+                reason="TODO(maca): [Warpgroup] maca c500 not support warpgroup"
+            ),
+        ),
+        pytest.param(
+            "warpgroup",
+            128,
+            32,
+            marks=pytest.mark.xfail(
+                reason="TODO(maca): [Warpgroup] maca c500 not support warpgroup"
+            ),
+        ),
+        pytest.param(
+            "warpgroup",
+            128,
+            8,
+            marks=pytest.mark.xfail(
+                reason="TODO(maca): [Warpgroup] maca c500 not support warpgroup"
+            ),
+        ),
+        ("warp", 64, 8),
+        ("warp", 64, 16),
         ("cta", 256, 8),
         ("cta", 256, 16),
     ],

--- a/tests/python/tirx/test_exec_context.py
+++ b/tests/python/tirx/test_exec_context.py
@@ -48,7 +48,7 @@ W_INNER = LaneBinding(axis="warpid", kind=LANE_W_INNER, declared_extent=4)
 LANE_BIND = LaneBinding(axis="laneid", kind=LANE_FLAT, declared_extent=32)
 CTA_BIND = LaneBinding(axis="cta_id", kind=LANE_FLAT, declared_extent=1)
 CTA_THREAD_BIND = LaneBinding(axis="thread", kind=LANE_CTA_THREAD, declared_extent=256)
-WG_THREAD_BIND = LaneBinding(axis="thread", kind=LANE_WG_THREAD, declared_extent=128)
+WG_THREAD_BIND = LaneBinding(axis="thread", kind=LANE_WG_THREAD, declared_extent=256)
 
 
 # ---------------------------------------------------------------------------
@@ -58,16 +58,16 @@ WG_THREAD_BIND = LaneBinding(axis="thread", kind=LANE_WG_THREAD, declared_extent
 
 def test_initial_A_single_cta():
     A = initial_A(warp_ext=16)
-    assert A.laneid == AxisRange(32, 0)
+    assert A.laneid == AxisRange(64, 0)
     assert A.warpid == AxisRange(16, 0)
     assert A.cta_id == AxisRange(1, 0)
-    assert A.size == 512
+    assert A.size == 1024
 
 
 def test_initial_A_cluster():
     A = initial_A(warp_ext=16, cta_ext=4)
     assert A.cta_id == AxisRange(4, 0)
-    assert A.size == 2048
+    assert A.size == 4096
 
 
 def test_axis_modulo_filter_uses_stride():
@@ -105,7 +105,7 @@ def test_scope_switch_warpgroup_aligned():
     split = scope_switch(A, WARPGROUP)
     assert split.inter["wgid"] == AxisRange(4, 0)
     assert split.inter["cta_id"] == AxisRange(1, 0)
-    assert split.intra["laneid"] == AxisRange(32, 0)
+    assert split.intra["laneid"] == AxisRange(64, 0)
     assert split.intra["wid_in_wg"] == AxisRange(4, 0)
 
 
@@ -351,14 +351,14 @@ def test_filter_out_of_range_rejected():
 
 def test_filter_flat_cta_thread_full_warp_range():
     A = initial_A(warp_ext=8)
-    A = filter_narrow(A, CTA_THREAD_BIND, 0, 128)
+    A = filter_narrow(A, CTA_THREAD_BIND, 0, 256)
     assert A.warpid == AxisRange(4, 0)
-    assert A.laneid == AxisRange(32, 0)
+    assert A.laneid == AxisRange(64, 0)
 
 
 def test_filter_flat_cta_thread_single_warp_lane_range():
     A = initial_A(warp_ext=8)
-    A = filter_narrow(A, CTA_THREAD_BIND, 34, 40)
+    A = filter_narrow(A, CTA_THREAD_BIND, 66, 72)
     assert A.warpid == AxisRange(1, 1)
     assert A.laneid == AxisRange(6, 2)
 
@@ -366,22 +366,22 @@ def test_filter_flat_cta_thread_single_warp_lane_range():
 def test_filter_flat_cta_thread_nonrectangular_rejected():
     A = initial_A(warp_ext=8)
     with pytest.raises(ExecContextError, match="non-rectangular"):
-        filter_narrow(A, CTA_THREAD_BIND, 20, 50)
+        filter_narrow(A, CTA_THREAD_BIND, 20, 70)
 
 
 def test_filter_flat_warpgroup_thread_range_inside_one_warpgroup():
     A = initial_A(warp_ext=8)
     A = filter_narrow(A, WG_OUTER, 1, 2)
-    A = filter_narrow(A, WG_THREAD_BIND, 32, 64)
+    A = filter_narrow(A, WG_THREAD_BIND, 64, 128)
     assert A.warpid == AxisRange(1, 5)
-    assert A.laneid == AxisRange(32, 0)
+    assert A.laneid == AxisRange(64, 0)
 
 
 def test_filter_flat_warpgroup_thread_full_range_across_warpgroups_is_noop():
     A = initial_A(warp_ext=8)
-    A2 = filter_narrow(A, WG_THREAD_BIND, 0, 128)
+    A2 = filter_narrow(A, WG_THREAD_BIND, 0, 256)
     assert A2.warpid == AxisRange(8, 0)
-    assert A2.laneid == AxisRange(32, 0)
+    assert A2.laneid == AxisRange(64, 0)
 
 
 def test_filter_flat_warpgroup_thread_partial_range_across_warpgroups_rejected():

--- a/tests/scripts/task_python_unittest.sh
+++ b/tests/scripts/task_python_unittest.sh
@@ -28,7 +28,7 @@ uv pip install -v --target=python ./3rdparty/tvm-ffi/
 
 # NOTE: also set by task_python_unittest_gpuonly.sh.
 if [ -z "${TVM_UNITTEST_TESTSUITE_NAME:-}" ]; then
-    TVM_UNITTEST_TESTSUITE_NAME=python-unittest
+  TVM_UNITTEST_TESTSUITE_NAME=python-unittest
 fi
 
 # First run minimal test on both ctypes and cython.
@@ -61,5 +61,5 @@ TEST_FILES=(
 )
 
 for TEST_FILE in ${TEST_FILES[@]}; do
-    run_pytest ${TEST_FILE}, tests/python/${TEST_FILE} -n 4
+  run_pytest ${TEST_FILE}, tests/python/${TEST_FILE} -n 2
 done


### PR DESCRIPTION
1. Register MACA TVMScript intrinsics and tile copy dispatches
2. Align execution-context handling with 64-lane warps.
3. Update affected TIRX tests.