### PR TITLE
[MetaX][BugFix] fix float accuracy error, support thread_return and loop start with non-zero

### DIFF
--- a/src/backend/maca/codegen/codegen_maca.cc
+++ b/src/backend/maca/codegen/codegen_maca.cc
@@ -489,8 +489,10 @@ std::string CodeGenMACA::Finish() {
 }
 
 void CodeGenMACA::VisitStmt_(const tirx::ForNode* op) {
-  TVM_FFI_ICHECK(is_const_int(op->min, 0));
-  if (op->kind == tirx::ForKind::kUnrolled) {
+  if (op->annotations.count("disable_unroll")) {
+    PrintIndent();
+    stream << "#pragma unroll 1\n";
+  } else if (op->kind == tirx::ForKind::kUnrolled || op->annotations.count("pragma_unroll")) {
     PrintIndent();
     stream << "#pragma unroll\n";
   }
@@ -1209,6 +1211,8 @@ void CodeGenMACA::VisitExpr_(const CallNode* op, std::ostream& os) {
   } else if (op->op.same_as(maca_func_call_op) ||
              (op->op.as<Op>() && op->op.as<Op>().value()->name == "tirx.maca.func_call")) {
     print_maca_func_call(op, os);
+  } else if (op->op.same_as(builtin::thread_return())) {
+    os << "return";
   } else {
     CodeGenC::VisitExpr_(op, os);
   }
@@ -1598,13 +1602,17 @@ inline void PrintConst(const FloatImmNode* op, std::ostream& os, CodeGenMACA* p)
   // Type code is kBFloat
   if (IsBFloat16(op_ty)) {
     os << "__float2bfloat16_rn";
-    os << '(' << std::scientific << op->value << 'f' << ')';
+    os << '(' << std::hexfloat << op->value << 'f';
+    os << "/*" << std::scientific << op->value << "*/";
+    os << ')';
     return;
   }
   // Type code is kFloat8_e5m2 or kE4M4Float
   if (IsFloat8(op_ty)) {
     p->PrintType(op_ty, os);
-    os << '(' << std::scientific << op->value << 'f' << ')';
+    os << '(' << std::hexfloat << op->value << 'f';
+    os << "/*" << std::scientific << op->value << "*/";
+    os << ')';
     return;
   }
   // Type code is kFloat
@@ -1622,8 +1630,9 @@ inline void PrintConst(const FloatImmNode* op, std::ostream& os, CodeGenMACA* p)
         temp << ((op_ty.bits() == 32) ? "MACART_NAN_F" : "MACART_NAN");
         p->need_math_constants_h_ = true;
       } else {
-        temp << std::scientific << op->value;
+        temp << std::hexfloat << op->value;
         if (op_ty.bits() == 32) temp << 'f';
+        temp << "/*" << std::scientific << op->value << "*/";
       }
       p->MarkConst(temp.str());
       os << temp.str();

--- a/src/backend/maca/codegen/codegen_maca.cc
+++ b/src/backend/maca/codegen/codegen_maca.cc
@@ -1600,7 +1600,7 @@ void CodeGenMACA::VisitExpr_(const SelectNode* op, std::ostream& os) {
 inline void PrintConst(const FloatImmNode* op, std::ostream& os, CodeGenMACA* p) {  // NOLINT(*)
   PrimType op_ty = op->ty.as_or_throw<PrimType>();
   // Type code is kBFloat
-  if (IsBFloat16(op_ty)) {
+  if (op_ty.MatchesElementType(DLDataTypeCode::kDLBfloat, 16)) {
     os << "__float2bfloat16_rn";
     os << '(' << std::hexfloat << op->value << 'f';
     os << "/*" << std::scientific << op->value << "*/";
@@ -1617,21 +1617,41 @@ inline void PrintConst(const FloatImmNode* op, std::ostream& os, CodeGenMACA* p)
   }
   // Type code is kFloat
   switch (op_ty.bits()) {
-    case 64:
+    case 64: {
+      std::ostringstream temp;
+      if (std::isinf(op->value)) {
+        if (op->value < 0) {
+          temp << "-";
+        }
+        temp << "MACART_INF";
+        p->codegen_tags_.insert("math_constants");
+        p->need_math_constants_h_ = true;
+      } else if (std::isnan(op->value)) {
+        temp << "MACART_NAN";
+        p->codegen_tags_.insert("math_constants");
+        p->need_math_constants_h_ = true;
+      } else {
+        temp << std::fixed << std::setprecision(15) << op->value;
+      }
+      p->MarkConst(temp.str());
+      os << temp.str();
+      break;
+    }
     case 32: {
       std::ostringstream temp;
       if (std::isinf(op->value)) {
         if (op->value < 0) {
           temp << "-";
         }
-        temp << ((op_ty.bits() == 32) ? "MACART_INF_F" : "MACART_INF");
+        temp << "MACART_INF_F";
+        p->codegen_tags_.insert("math_constants");
         p->need_math_constants_h_ = true;
       } else if (std::isnan(op->value)) {
-        temp << ((op_ty.bits() == 32) ? "MACART_NAN_F" : "MACART_NAN");
+        temp << "MACART_NAN_F";
+        p->codegen_tags_.insert("math_constants");
         p->need_math_constants_h_ = true;
       } else {
-        temp << std::hexfloat << op->value;
-        if (op_ty.bits() == 32) temp << 'f';
+        temp << std::hexfloat << op->value << 'f';
         temp << "/*" << std::scientific << op->value << "*/";
       }
       p->MarkConst(temp.str());
@@ -1639,14 +1659,14 @@ inline void PrintConst(const FloatImmNode* op, std::ostream& os, CodeGenMACA* p)
       break;
     }
     case 16: {
-      os << "__float2half" << '(';
+      os << "__float2half_rn" << '(';
       FloatImm const_f32 = FloatImm(PrimType::Float(32), op->value);
       PrintConst(const_f32.get(), os, p);
       os << ')';
       break;
     }
     default:
-      LOG(FATAL) << "Bad bit-width for float: " << op_ty << "\n";
+      TVM_FFI_THROW(InternalError) << "Bad bit-width for float: " << op_ty << "\n";
   }
 }
 

--- a/src/backend/maca/codegen/codegen_maca.h
+++ b/src/backend/maca/codegen/codegen_maca.h
@@ -143,6 +143,8 @@ class CodeGenMACA final : public CodeGenC {
   bool need_mma_h_{false};
   // whether need cast_smem_ptr_to_int helper function
   bool need_cast_smem_ptr_to_int_{false};
+  // Codegen tags
+  std::unordered_set<std::string> codegen_tags_;
   // Op attribute map
   OpAttrMap<bool> op_need_warp_shuffle_ = Op::GetAttrMap<bool>("maca.need_warp_shuffle");
 

--- a/tests/python/codegen/test_target_codegen_cuda.py
+++ b/tests/python/codegen/test_target_codegen_cuda.py
@@ -1045,10 +1045,6 @@ def test_cuda_device_func_call():
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(
-    reason="TODO(maca): [float-literal] preserve hexadecimal float literal formatting in generated source",
-    strict=False,
-)
 def test_cuda_float_const_hex_format():
     """Test that float constants are emitted in hexadecimal format for precision"""
 
@@ -1118,10 +1114,6 @@ def test_device_host_call_same_func():
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(
-    reason="TODO(maca): [thread-return] lower tirx.thread_return to device-kernel return statements",
-    strict=False,
-)
 def test_thread_return():
     @I.ir_module(s_tir=True)
     class Module:
@@ -1140,10 +1132,6 @@ def test_thread_return():
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(
-    reason="TODO(maca): [thread-bound-loop] support thread-bound serial loops with non-zero minimum values",
-    strict=False,
-)
 def test_cuda_loop_step():
     @T.prim_func(s_tir=True)
     def cuda_loop_step(


### PR DESCRIPTION
fix: test/python/codegen/test_target_codegen_cuda.py

1. Use hexadecimal float instead of decimal float, and note the decimal values in the comments.
2. Support tirx.thread_return in codegen.
3. Support loop start with non-zero in codegen.

These changes above is following cuda code.