### PR TITLE
[TIRx][MACA] Support Triton kernel launch ABI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,6 +205,24 @@ jobs:
           --junit-prefix=cython
           tests/python/codegen || test $? -eq 5
 
+      - name: Run 'contrib' unittests
+        if: ${{ !cancelled() && steps.pytest_setup.outcome == 'success' }}
+        run: >-
+          python3 -m pytest -vvs -n 2
+          -o "junit_suite_name=python-unittest-gpu-contrib"
+          --junit-xml="${TVM_PYTEST_RESULT_DIR}/python-unittest-gpu-contrib.xml"
+          --junit-prefix=cython
+          tests/python/contrib || test $? -eq 5
+
+      - name: Run 'disco' unittests
+        if: ${{ !cancelled() && steps.pytest_setup.outcome == 'success' }}
+        run: >-
+          python3 -m pytest -vvs -n 2
+          -o "junit_suite_name=python-unittest-gpu-disco"
+          --junit-xml="${TVM_PYTEST_RESULT_DIR}/python-unittest-gpu-disco.xml"
+          --junit-prefix=cython
+          tests/python/disco || test $? -eq 5
+
       - name: Run 'driver' unittests
         if: ${{ !cancelled() && steps.pytest_setup.outcome == 'success' }}
         run: >-
@@ -312,6 +330,24 @@ jobs:
           --junit-xml="${TVM_PYTEST_RESULT_DIR}/python-unittest-gpu-s-tir-transform.xml"
           --junit-prefix=cython
           tests/python/s_tir/transform || test $? -eq 5
+
+      - name: Run 's_tir/root' unittests
+        if: ${{ !cancelled() && steps.pytest_setup.outcome == 'success' }}
+        run: >-
+          python3 -m pytest -vvs -n 2
+          -o "junit_suite_name=python-unittest-gpu-s-tir-root"
+          --junit-xml="${TVM_PYTEST_RESULT_DIR}/python-unittest-gpu-s-tir-root.xml"
+          --junit-prefix=cython
+          tests/python/s_tir/test_s_tir_renew_defs.py || test $? -eq 5
+
+      - name: Run 'support' unittests
+        if: ${{ !cancelled() && steps.pytest_setup.outcome == 'success' }}
+        run: >-
+          python3 -m pytest -vvs -n 2
+          -o "junit_suite_name=python-unittest-gpu-support"
+          --junit-xml="${TVM_PYTEST_RESULT_DIR}/python-unittest-gpu-support.xml"
+          --junit-prefix=cython
+          tests/python/support || test $? -eq 5
 
       - name: Run 'tirx-analysis' unittests
         if: ${{ !cancelled() && steps.pytest_setup.outcome == 'success' }}

--- a/python/tvm/tirx/script/builder/triton.py
+++ b/python/tvm/tirx/script/builder/triton.py
@@ -100,6 +100,56 @@ class TritonKernel(BaseKernel):
 
         return triton_kernel.name, kernel_module, kernel_args + launch_args
 
+    def compile_to_device_module_maca(
+        self,
+        launch_args: list[int | tirx.Expr],
+        *args: list[Any],
+        **kwargs: dict[str, Any],
+    ) -> tuple[str, Module, list[Any]]:
+        """Compile a Triton kernel for MACA and adapt its launcher ABI."""
+        triton_kernel, all_kernel_args = self._generate_triton_kernel(self.func, *args, **kwargs)
+        kernel_metadata = triton_kernel.metadata
+        if getattr(kernel_metadata, "global_scratch_size", 0) or getattr(
+            kernel_metadata, "profile_scratch_size", 0
+        ):
+            raise NotImplementedError(
+                "MACA Triton kernels requiring global or profile scratch are not supported"
+            )
+        assert kernel_metadata.num_ctas == 1, "Cluster is not supported"
+
+        # MetaX Triton elides constexpr parameters and appends two scratch pointers.
+        kernel_args = [
+            arg
+            for kernel_param, arg in zip(self.func.params, all_kernel_args)
+            if not kernel_param.is_constexpr
+        ]
+        kernel_arg_types = []
+        for arg in kernel_args:
+            if isinstance(arg.ty, PointerType):
+                kernel_arg_types.append("handle")
+            else:
+                assert is_prim_expr(arg)
+                kernel_arg_types.append(str(arg.ty.dtype))
+        kernel_arg_types.extend(["handle", "handle"])
+
+        grid = launch_args
+        launch_param_tags = ["threadIdx.x"] + ["blockIdx.x", "blockIdx.y", "blockIdx.z"][
+            : len(grid)
+        ]
+        launch_args = [kernel_metadata.target.warp_size * kernel_metadata.num_warps] + list(grid)
+        if kernel_metadata.shared > 0:
+            launch_param_tags.append("tirx.use_dyn_shared_memory")
+            launch_args.append(kernel_metadata.shared)
+
+        kernel_module = self._create_maca_module(
+            triton_kernel.asm["mcfatbin"],
+            kernel_arg_types,
+            launch_param_tags,
+            triton_kernel.name,
+            fmt="mcfatbin",
+        )
+        return triton_kernel.name, kernel_module, kernel_args + [0, 0] + launch_args
+
     def _generate_triton_kernel(
         self, func, *args, **kwargs
     ) -> tuple["triton.compiler.CompiledKernel", list[tirx.Expr]]:

--- a/src/backend/maca/codegen/build_maca_on.cc
+++ b/src/backend/maca/codegen/build_maca_on.cc
@@ -186,8 +186,7 @@ ffi::Module BuildMACA(IRModule mod, Target target) {
   }
   std::string fmt = "mcir";
   std::string mcir;
-  auto f_enter = ffi::Function::GetGlobal("target.TargetEnterScope");
-  (*f_enter)(target);
+  With<Target> target_scope(target);
   if (auto f = ffi::Function::GetGlobal("tvm_callback_maca_compile")) {
     mcir = (*f)(code, target).cast<std::string>();
     // Dirty matching to check mcir vs mcbin.
@@ -196,8 +195,6 @@ ffi::Module BuildMACA(IRModule mod, Target target) {
   } else {
     mcir = MCRTCCompile(code, cg.need_include_path());
   }
-  auto f_exit = ffi::Function::GetGlobal("target.TargetExitScope");
-  (*f_exit)(target);
   return ::tvm::target::MACAModuleCreateWithFallback(ffi::Bytes(std::move(mcir)), ffi::String(fmt),
                                                      ExtractFuncInfo(mod), ffi::String(code));
 }

--- a/tests/python/contrib/test_tir_triton_integration.py
+++ b/tests/python/contrib/test_tir_triton_integration.py
@@ -93,8 +93,8 @@ def test_tir_triton_integration():
                 R.output(output)
             return output
 
-    # Constexpr parameters (BLOCK_SIZE) stay in the kernel arguments, and the
-    # thread extent is 256 because the kernel is compiled with num_warps=8.
+    # MetaX Triton elides constexpr parameters, appends two scratch pointers,
+    # and uses 64 lanes per warp.
     @I.ir_module(s_tir=True)
     class Parsed:
         @T.prim_func(s_tir=True)
@@ -112,8 +112,9 @@ def test_tir_triton_integration():
                     y.data,
                     output.data,
                     m,
-                    64,
-                    256,
+                    0,
+                    0,
+                    512,
                     (m + T.int64(64) - T.int64(1)) // T.int64(64),
                 )
 


### PR DESCRIPTION
Align TIRx Triton module generation with the MACA launcher ABI so generated kernels receive the argument layout and launch metadata expected by the device runtime.

Changes:
- Add a MACA device-module compilation path that omits constexpr parameters from serialized kernel arguments.
- Append the two scratch handles required by the ABI and reject kernels that request unsupported global or profile scratch storage.
- Preserve pointer and scalar argument types and encode launch metadata for the 64-lane warp-derived thread extent, grid dimensions, and dynamic shared memory.
- Scope MACA compilation with With<Target> so the target context is restored safely after compilation.
- Update Triton integration expectations for omitted constexpr arguments, scratch handles, and MACA launch dimensions.
- Extend GPU CI coverage to the contrib, disco, s_tir/root, and support test suites.
