### PR TITLE
[TIRx][MACA] Add warpgroup support to tile-copy lowering

### DIFF
--- a/python/tvm/backend/maca/operator/tile_primitive/copy/_common.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/copy/_common.py
@@ -54,6 +54,7 @@ def _alignment_ok(vec_len: int, terms) -> bool:
 # scope_kind → name of the scope_id that decomposes the scope into per-thread.
 _TID_AXIS_FOR_SCOPE = {
     "warp": "laneid",
+    "warpgroup": "tid_in_wg",
     "cta": "tx",
 }
 

--- a/python/tvm/backend/maca/operator/tile_primitive/copy/fallback.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/copy/fallback.py
@@ -89,10 +89,14 @@ def _emit_fallback(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFun
         return impl
 
     tid_axis_name = _TID_AXIS_FOR_SCOPE[scope_kind]
-    # first-active tid = composition of per-axis offsets (radix-64, since a warp is 64 lanes)
+    # first-active tid = composition of per-axis offsets (radix-64, since a
+    # MACA warp is 64 lanes).  A warpgroup's fused thread id includes the
+    # four-warp ``wid_in_wg`` component.
     first_tid = int(sctx.intra["laneid"][1])
     if scope_kind == "cta":
         first_tid += 64 * int(sctx.intra["warpid"][1])
+    elif scope_kind == "warpgroup":
+        first_tid += 64 * int(sctx.intra["wid_in_wg"][1])
 
     @T.prim_func(check_well_formed=False)
     def impl():

--- a/python/tvm/backend/maca/operator/tile_primitive/copy/gmem_smem.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/copy/gmem_smem.py
@@ -89,7 +89,7 @@ def _divides_thread_cnt(
 def _is_gmem_smem(op_call: TilePrimitiveCall, sctx: DispatchContext) -> tuple[bool, str | None]:
     if not sctx.is_target("maca"):
         return False, "non-maca target"
-    if sctx.scope_kind not in ("thread", "warp", "cta"):
+    if sctx.scope_kind not in ("thread", "warp", "warpgroup", "cta"):
         return False, f"unsupported exec_scope {sctx.scope_kind}"
     for check in (
         lambda: _all_threads_active(sctx),
@@ -283,7 +283,7 @@ def _emit_gmem_smem(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFu
             g_lin = g_p.apply(f, tid, v0, shape=apply_shape)["m"]
             s_off = _s_off(f, s_lin)
             # Pointer-valued calls are general Exprs after the IR type
-            # migration.  Bind them explicitly so the TIRx parser does not
+            # migration. Bind them explicitly so the TIRx parser does not
             # try to infer a scalar constant type for the call result.
             s_ptr: T.let = _ptr_off(s_buf.ptr_to(s_zero), s_off)
             g_ptr: T.let = _ptr_off(g_buf.ptr_to(g_zero), g_lin)

--- a/python/tvm/backend/maca/operator/tile_primitive/copy/reg.py
+++ b/python/tvm/backend/maca/operator/tile_primitive/copy/reg.py
@@ -83,6 +83,8 @@ def _all_threads_active(sctx: DispatchContext) -> tuple[bool, str | None]:
     required: dict[str, int] = {}
     if sctx.scope_kind in ("warp", "warpgroup", "cta"):
         required["laneid"] = 64
+    if sctx.scope_kind == "warpgroup":
+        required["wid_in_wg"] = 4
     if sctx.scope_kind == "cta":
         tx_iv = sctx.launch_params.get("threadIdx.x")
         if tx_iv is None:
@@ -177,7 +179,7 @@ def _s_side_slice_ok(op_call: TilePrimitiveCall) -> tuple[bool, str | None]:
 def _is_reg_copy(op_call: TilePrimitiveCall, sctx: DispatchContext) -> tuple[bool, str | None]:
     if not sctx.is_target("maca"):
         return False, "non-maca target"
-    if sctx.scope_kind not in ("thread", "warp", "cta"):
+    if sctx.scope_kind not in ("thread", "warp", "warpgroup", "cta"):
         return False, f"unsupported exec_scope {sctx.scope_kind}"
     for check in (
         lambda: _all_threads_active(sctx),

--- a/src/tirx/ir/exec_scope.cc
+++ b/src/tirx/ir/exec_scope.cc
@@ -445,11 +445,22 @@ ffi::Array<PrimExpr> ResolveMACA(ScopeBinding binding,
       return {ana->Simplify(FloorMod(GetLinearThreadIndex(params), 64))};
     }
     case ScopeBinding::kKernelCluster:
+      LOG(WARNING) << "kKernelCluster not supported in MACA";
+      break;
     case ScopeBinding::kClusterCta:
+      LOG(WARNING) << "kClusterCta not supported in MACA";
+      break;
     case ScopeBinding::kCtaWarpgroup:
+      TVM_FFI_ICHECK_EQ(out_dim, 1) << "ValueError: cta->warpgroup must be 1D";
+      return {ana->Simplify(FloorDiv(GetThread("warp_id_in_cta", params).first, 4))};
     case ScopeBinding::kWarpgroupWarp:
+      TVM_FFI_ICHECK_EQ(out_dim, 1) << "ValueError: warpgroup->warp must be 1D";
+      return {ana->Simplify(FloorMod(GetThread("warp_id_in_cta", params).first, 4))};
     case ScopeBinding::kWarpgroupThread:
+      TVM_FFI_ICHECK_EQ(out_dim, 1) << "ValueError: warpgroup->thread must be 1D";
+      return {ana->Simplify(FloorMod(GetLinearThreadIndex(params), 256))};
     case ScopeBinding::kClusterCtaPair:
+      LOG(WARNING) << "kClusterCtaPair not supported in MACA";
       break;
   }
   LOG(FATAL) << "Internal Error: unknown ScopeBinding " << static_cast<int>(binding);

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_fallback.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_fallback.py
@@ -40,14 +40,6 @@ from tvm.testing import env
 from tvm.tirx.cuda.operator.tile_primitive.copy import fallback as _fallback_module  # noqa: F401
 from tvm.tirx.layout import S, TileLayout
 
-MACA_XFAIL = pytest.mark.xfail(
-    reason=(
-        "TODO(maca): [tile-primitive-copy-fallback] support fallback copy dispatch "
-        "and scalar gated emit"
-    ),
-    strict=False,
-)
-
 
 def _round_trip_shapes_and_threads():
     """Cases where ``gmem_smem`` rejects on ``n_elements % thread_cnt``.
@@ -57,14 +49,14 @@ def _round_trip_shapes_and_threads():
     variants can't accept it (size doesn't divide thread_cnt).
     """
     return [
-        # warp scope, 64 threads, 24 elements (4x6) → 24 % 32 != 0.
-        ("warp", 64, (4, 6), "4*6=24 ∤ 32"),
-        # warp scope, 64 threads, 8 elements (1x8) → 8 % 32 != 0.
-        ("warp", 64, (1, 8), "1*8=8 ∤ 32"),
-        # warpgroup scope, 128 threads, 24 elements (4x6) → 24 % 128 != 0.
-        ("warpgroup", 128, (4, 6), "4*6=24 ∤ 128"),
-        # warpgroup scope, 128 threads, 32 elements (4x8) → 32 % 128 != 0.
-        ("warpgroup", 128, (4, 8), "4*8=32 ∤ 128"),
+        # warp scope, 64 threads, 24 elements (4x6) → 24 % 64 != 0.
+        ("warp", 64, (4, 6), "4*6=24 ∤ 64"),
+        # warp scope, 64 threads, 8 elements (1x8) → 8 % 64 != 0.
+        ("warp", 64, (1, 8), "1*8=8 ∤ 64"),
+        # warpgroup scope, 256 threads, 24 elements (4x6) → 24 % 256 != 0.
+        ("warpgroup", 256, (4, 6), "4*6=24 ∤ 256"),
+        # warpgroup scope, 256 threads, 32 elements (4x8) → 32 % 256 != 0.
+        ("warpgroup", 256, (4, 8), "4*8=32 ∤ 256"),
         # cta scope, 256 threads, 32 elements (4x8) → 32 % 256 != 0.
         ("cta", 256, (4, 8), "4*8=32 ∤ 256"),
         # cta scope, 1024 threads, 64 elements (8x8) → 64 % 1024 != 0.
@@ -105,14 +97,14 @@ def _build_round_trip_kernel(scope, n_threads, shape, dtype):
             B = T.match_buffer(B_ptr, shape, dtype)
             T.device_entry()
             T.cta_id([1])
-            T.warpgroup_id([n_threads // 128])
+            T.warpgroup_id([n_threads // 256])
             T.warp_id_in_wg([4])
-            T.lane_id([32])
-            T.thread_id_in_wg([128])
+            T.lane_id([64])
+            T.thread_id_in_wg([256])
             T.thread_id([n_threads])
             A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
             Tx.wg.copy(A_smem[full], A[full])
-            T.cuda.cta_sync()
+            T.maca.cta_sync()
             Tx.wg.copy(B[full], A_smem[full])
 
     elif scope == "cta":
@@ -142,18 +134,7 @@ def _build_round_trip_kernel(scope, n_threads, shape, dtype):
 @pytest.mark.parametrize(
     "scope,n_threads,shape,why",
     [
-        pytest.param(
-            s,
-            n,
-            sh,
-            w,
-            id=f"{s}-{n}-{'x'.join(map(str, sh))}",
-            marks=pytest.mark.xfail(
-                reason="TODO(maca): [tile-primitive-copy-fallback] support warpgroup"
-            )
-            if s == "warpgroup"
-            else (),
-        )
+        pytest.param(s, n, sh, w, id=f"{s}-{n}-{'x'.join(map(str, sh))}")
         for s, n, sh, w in _round_trip_shapes_and_threads()
     ],
 )
@@ -242,8 +223,8 @@ def test_fallback_emits_gate():
         B = T.match_buffer(B_ptr, shape, dtype)
         T.device_entry()
         T.cta_id([1])
-        T.warp_id([8])  # 256 threads => 8 warps
-        T.lane_id([32])
+        T.warp_id([4])  # 256 threads => 4 Wave64 warps
+        T.lane_id([64])
         T.thread_id([256])
         A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
         Tx.cta.copy(A_smem[full], A[full])

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_gmem_smem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_gmem_smem.py
@@ -31,13 +31,6 @@ from tvm.script.tirx import tile as Tx
 from tvm.testing import env
 from tvm.tirx.layout import ComposeLayout, S, SwizzleLayout, TileLayout
 
-MACA_XFAIL = pytest.mark.xfail(
-    reason=(
-        "TODO(maca): [tile-primitive-copy-gmem-smem] warpgroup execution scope is not supported"
-    ),
-    strict=False,
-)
-
 
 def _build_kernel(scope, n_threads, shape, dtype):
     s_layout = TileLayout(S[shape])
@@ -57,9 +50,9 @@ def _build_kernel(scope, n_threads, shape, dtype):
             T.thread_id_in_wg([256])
             T.thread_id([n_threads])
             A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
-            Tx.wg.copy(A_smem[full_slices], A[full_slices])
+            Tx.wg.copy(A_smem[full_slices], A[full_slices], dispatch="gmem_smem")
             T.maca.cta_sync()
-            Tx.wg.copy(B[full_slices], A_smem[full_slices])
+            Tx.wg.copy(B[full_slices], A_smem[full_slices], dispatch="gmem_smem")
 
     elif scope == "warp":
 
@@ -102,7 +95,7 @@ def _build_kernel(scope, n_threads, shape, dtype):
 TASKS = [
     ("warp", 64, (32, 32)),  # 1024 total, T=64, vec 8 → outer 2
     ("warp", 64, (32, 64)),  # 2048 total, outer 4
-    ("warpgroup", 256, (128, 32)),  # 4096, outer 2 (4 MACA warps)
+    ("warpgroup", 256, (128, 32)),  # 4096, outer 2
     ("warpgroup", 256, (128, 64)),  # 8192, outer 4
     ("warpgroup", 256, (256, 16)),  # 4096, outer 2
     ("cta", 256, (256, 32)),  # 8192, T=256, vec 8 → outer 4
@@ -114,14 +107,7 @@ TASKS = [
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
 @pytest.mark.parametrize(
     "scope,n_threads,shape",
-    [
-        pytest.param(
-            *t,
-            id=f"{t[0]}-{t[1]}-{'x'.join(map(str, t[2]))}",
-            marks=MACA_XFAIL if t[0] == "warpgroup" else (),
-        )
-        for t in TASKS
-    ],
+    [pytest.param(*t, id=f"{t[0]}-{t[1]}-{'x'.join(map(str, t[2]))}") for t in TASKS],
 )
 @pytest.mark.parametrize("dtype", ["float16", "float32", "uint8"])
 def test_gmem_smem_roundtrip(scope, n_threads, shape, dtype):
@@ -210,17 +196,9 @@ def test_gmem_smem_roundtrip(scope, n_threads, shape, dtype):
     ],
 )
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_maca(), reason="need cuda")
 @pytest.mark.parametrize(
-    "dtype",
-    [
-        "int8",
-        "float8_e4m3fn",
-        "float8_e5m2",
-        "float16",
-        "bfloat16",
-        "float32",
-    ],
+    "dtype", ["int8", "float8_e4m3fn", "float8_e5m2", "float16", "bfloat16", "float32"]
 )
 @pytest.mark.parametrize("scope", ["cta", "thread"])
 def test_copy_g2s_s2g(task, dtype, scope):
@@ -266,9 +244,6 @@ def test_copy_g2s_s2g(task, dtype, scope):
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            # NumPy's float8/bfloat16 dtypes do not promote with the scalar
-            # literals used by ``assert_allclose``. Compare their numerical
-            # values in float32 instead.
             np.testing.assert_allclose(B_ref.astype("float32"), B.numpy().astype("float32"))
 
         tvm.testing.run_with_gpu_lock(run_and_check)
@@ -277,9 +252,8 @@ def test_copy_g2s_s2g(task, dtype, scope):
 # ----------------------------------------------------------------------------
 # Regression tests for known correctness gaps in ``align_layouts_gs``.
 #
-# These are intentionally algorithm-level (no GPU runtime) and currently
-# XFAIL; flipping them to passing is the contract for the upcoming swizzle /
-# alignment fix.
+# These are intentionally algorithm-level (no GPU runtime) and validate the
+# MACA alignment implementation directly.
 # ----------------------------------------------------------------------------
 
 
@@ -306,10 +280,6 @@ def _align(
         )
 
 
-@pytest.mark.xfail(
-    reason="align_layouts_gs ignores swizzle chunk size; "
-    "_extract_tile strips the swizzle wrap before vec_len pick."
-)
 @pytest.mark.parametrize("per_element,expected_max_vec", [(2, 4), (1, 2), (0, 1)])
 def test_swizzled_smem_vec_len_must_fit_chunk(per_element, expected_max_vec):
     """``SwizzleLayout(per_element, ...)`` keeps the bottom ``per_element``
@@ -372,13 +342,8 @@ def test_unaligned_region_offset_must_clamp_vec_len():
     )
 
 
-@MACA_XFAIL
 def test_swizzled_smem_emit_must_be_swizzle_aware():
-    """Codegen-level regression for swizzled shared-memory addressing.
-
-    The case remains xfailed until MACA supports the warpgroup execution
-    scope used by this CUDA-derived swizzle pattern.
-    """
+    """Codegen-level: emitted S address must honor the SwizzleLayout."""
     import tvm
     from tvm.script import tirx as T
     from tvm.tirx.layout import ComposeLayout, S, SwizzleLayout, TileLayout
@@ -397,11 +362,8 @@ def test_swizzled_smem_emit_must_be_swizzle_aware():
         T.thread_id_in_wg([256])
         T.thread_id([256])
         A_smem = T.alloc_buffer(shape, "float16", scope="shared", layout=s_layout)
-        Tx.wg.copy(A_smem[0:128, 0:32], A[0:128, 0:32])
+        Tx.wg.copy(A_smem[0:128, 0:32], A[0:128, 0:32], dispatch="gmem_smem")
 
-    # MACA uses ``mcpu`` rather than CUDA's ``arch`` target option.  Keep the
-    # target construction valid even though this warpgroup case is expected
-    # to remain unsupported on MACA.
     target = tvm.target.Target("maca")
     with target:
         mod = tvm.IRModule({"main": kernel})
@@ -537,7 +499,7 @@ def test_layout_permute_copy_preserves_smem_strides():
 #
 # Setup: warp-scope 64x64 fp16 G2S/S2G with 128b swizzled SMEM. The outer
 # iter stride is ``thread_cnt * vec_len = 64 * 8 = 512``, which puts the
-# binary-split bj's above the swizzle XOR region (so
+# binary-split bj's at {6, 7, 8} — well above the swizzle XOR region (so
 # Case 1.D, signed_stride = +T). The (C1) analyzer check
 # ``bit_bj(s_off // C) == 0`` needs the placeholder var bounded to
 # laneid ∈ [0, 64); the dispatch passes ``var_bounds`` so it can discharge,
@@ -578,8 +540,7 @@ def test_gmem_smem_swizzle_fast_path_fires_with_var_bounds():
 
     bitsel = re.findall(r"& 1\) \* v_\d+\[", src)
     v_decls = re.findall(
-        r"(?:alignas\(\d+\)|__attribute__\(\(aligned\(\d+\)\)\)) "
-        r"int v_\d+\[(\d+)\]",
+        r"(?:alignas\(\d+\)|__attribute__\(\(aligned\(\d+\)\)\))\s+int v_\d+\[(\d+)\]",
         src,
     )
     assert bitsel, (
@@ -588,7 +549,7 @@ def test_gmem_smem_swizzle_fast_path_fires_with_var_bounds():
     )
     assert "3" in v_decls, (
         f"expected at least one 3-slot signed_strides buffer for bjs "
-        f"[7, 6, 5]; got decl sizes {v_decls}"
+        f"[8, 7, 6]; got decl sizes {v_decls}"
     )
 
     # Round-trip correctness.

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
@@ -38,11 +38,8 @@ from tvm.script.tirx import tile as Tx
 from tvm.testing import env
 from tvm.tirx.layout import S, TileLayout, laneid, tid_in_wg, tx
 
-MACA_XFAIL = pytest.mark.xfail(
-    reason=(
-        "TODO(maca): [tile-primitive-copy-reg] support register copy dispatch "
-        "and swizzled shared fast path"
-    ),
+_TCGEN05_XFAIL = pytest.mark.xfail(
+    reason=("TODO(maca): [tile-primitive-copy-reg] support TCGEN05 layouts"),
     strict=False,
 )
 
@@ -80,22 +77,22 @@ def _build_roundtrip_kernel(scope, n_threads, k, dtype, non_r_scope):
                 B = T.match_buffer(B_ptr, shape, dtype)
                 T.device_entry()
                 T.cta_id([1])
-                T.warpgroup_id([n_threads // 128])
+                T.warpgroup_id([n_threads // 256])
                 T.warp_id_in_wg([4])
-                T.lane_id([32])
-                T.thread_id_in_wg([128])
+                T.lane_id([64])
+                T.thread_id_in_wg([256])
                 tid = T.thread_id([n_threads])
                 A_smem = T.alloc_buffer(shape, dtype, scope="shared", layout=s_layout)
                 for kk in range(k):
                     A_smem[tid, kk] = T.cast(tid * 100 + kk + 1, dtype)
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 R_local = T.alloc_buffer(shape, dtype, scope="local", layout=r_layout)
-                Tx.wg.copy(R_local[full_slices], A_smem[full_slices])
+                Tx.wg.copy(R_local[full_slices], A_smem[full_slices], dispatch="reg")
                 for kk in range(k):
                     A_smem[tid, kk] = T.cast(0, dtype)
-                T.cuda.cta_sync()
-                Tx.wg.copy(A_smem[full_slices], R_local[full_slices])
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
+                Tx.wg.copy(A_smem[full_slices], R_local[full_slices], dispatch="reg")
+                T.maca.cta_sync()
                 for kk in range(k):
                     B[tid, kk] = A_smem[tid, kk]
 
@@ -113,11 +110,11 @@ def _build_roundtrip_kernel(scope, n_threads, k, dtype, non_r_scope):
                     A_smem[tid, kk] = T.cast(tid * 100 + kk + 1, dtype)
                 T.maca.cta_sync()
                 R_local = T.alloc_buffer(shape, dtype, scope="local", layout=r_layout)
-                Tx.warp.copy(R_local[full_slices], A_smem[full_slices])
+                Tx.warp.copy(R_local[full_slices], A_smem[full_slices], dispatch="reg")
                 for kk in range(k):
                     A_smem[tid, kk] = T.cast(0, dtype)
                 T.maca.cta_sync()
-                Tx.warp.copy(A_smem[full_slices], R_local[full_slices])
+                Tx.warp.copy(A_smem[full_slices], R_local[full_slices], dispatch="reg")
                 T.maca.cta_sync()
                 for kk in range(k):
                     B[tid, kk] = A_smem[tid, kk]
@@ -137,11 +134,11 @@ def _build_roundtrip_kernel(scope, n_threads, k, dtype, non_r_scope):
                     A_smem[tid, kk] = T.cast(tid * 100 + kk + 1, dtype)
                 T.maca.cta_sync()
                 R_local = T.alloc_buffer(shape, dtype, scope="local", layout=r_layout)
-                Tx.cta.copy(R_local[full_slices], A_smem[full_slices])
+                Tx.cta.copy(R_local[full_slices], A_smem[full_slices], dispatch="reg")
                 for kk in range(k):
                     A_smem[tid, kk] = T.cast(0, dtype)
                 T.maca.cta_sync()
-                Tx.cta.copy(A_smem[full_slices], R_local[full_slices])
+                Tx.cta.copy(A_smem[full_slices], R_local[full_slices], dispatch="reg")
                 T.maca.cta_sync()
                 for kk in range(k):
                     B[tid, kk] = A_smem[tid, kk]
@@ -157,21 +154,21 @@ def _build_roundtrip_kernel(scope, n_threads, k, dtype, non_r_scope):
                 B = T.match_buffer(B_ptr, shape, dtype)
                 T.device_entry()
                 T.cta_id([1])
-                T.warpgroup_id([n_threads // 128])
+                T.warpgroup_id([n_threads // 256])
                 T.warp_id_in_wg([4])
-                T.lane_id([32])
-                T.thread_id_in_wg([128])
+                T.lane_id([64])
+                T.thread_id_in_wg([256])
                 tid = T.thread_id([n_threads])
                 for kk in range(k):
                     A[tid, kk] = T.cast(tid * 100 + kk + 1, dtype)
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
                 R_local = T.alloc_buffer(shape, dtype, scope="local", layout=r_layout)
-                Tx.wg.copy(R_local[full_slices], A[full_slices])
+                Tx.wg.copy(R_local[full_slices], A[full_slices], dispatch="reg")
                 for kk in range(k):
                     A[tid, kk] = T.cast(0, dtype)
-                T.cuda.cta_sync()
-                Tx.wg.copy(A[full_slices], R_local[full_slices])
-                T.cuda.cta_sync()
+                T.maca.cta_sync()
+                Tx.wg.copy(A[full_slices], R_local[full_slices], dispatch="reg")
+                T.maca.cta_sync()
                 for kk in range(k):
                     B[tid, kk] = A[tid, kk]
 
@@ -189,11 +186,11 @@ def _build_roundtrip_kernel(scope, n_threads, k, dtype, non_r_scope):
                     A[tid, kk] = T.cast(tid * 100 + kk + 1, dtype)
                 T.maca.cta_sync()
                 R_local = T.alloc_buffer(shape, dtype, scope="local", layout=r_layout)
-                Tx.warp.copy(R_local[full_slices], A[full_slices])
+                Tx.warp.copy(R_local[full_slices], A[full_slices], dispatch="reg")
                 for kk in range(k):
                     A[tid, kk] = T.cast(0, dtype)
                 T.maca.cta_sync()
-                Tx.warp.copy(A[full_slices], R_local[full_slices])
+                Tx.warp.copy(A[full_slices], R_local[full_slices], dispatch="reg")
                 T.maca.cta_sync()
                 for kk in range(k):
                     B[tid, kk] = A[tid, kk]
@@ -213,11 +210,11 @@ def _build_roundtrip_kernel(scope, n_threads, k, dtype, non_r_scope):
                     A[tid, kk] = T.cast(tid * 100 + kk + 1, dtype)
                 T.maca.cta_sync()
                 R_local = T.alloc_buffer(shape, dtype, scope="local", layout=r_layout)
-                Tx.cta.copy(R_local[full_slices], A[full_slices])
+                Tx.cta.copy(R_local[full_slices], A[full_slices], dispatch="reg")
                 for kk in range(k):
                     A[tid, kk] = T.cast(0, dtype)
                 T.maca.cta_sync()
-                Tx.cta.copy(A[full_slices], R_local[full_slices])
+                Tx.cta.copy(A[full_slices], R_local[full_slices], dispatch="reg")
                 T.maca.cta_sync()
                 for kk in range(k):
                     B[tid, kk] = A[tid, kk]
@@ -243,30 +240,9 @@ def _expected(shape, dtype):
 @pytest.mark.parametrize(
     "scope,n_threads,k",
     [
-        pytest.param(
-            "warpgroup",
-            128,
-            16,
-            marks=pytest.mark.xfail(
-                reason="TODO(maca): [Warpgroup] maca c500 not support warpgroup"
-            ),
-        ),
-        pytest.param(
-            "warpgroup",
-            128,
-            32,
-            marks=pytest.mark.xfail(
-                reason="TODO(maca): [Warpgroup] maca c500 not support warpgroup"
-            ),
-        ),
-        pytest.param(
-            "warpgroup",
-            128,
-            8,
-            marks=pytest.mark.xfail(
-                reason="TODO(maca): [Warpgroup] maca c500 not support warpgroup"
-            ),
-        ),
+        ("warpgroup", 256, 16),
+        ("warpgroup", 256, 32),
+        ("warpgroup", 256, 8),
         ("warp", 64, 8),
         ("warp", 64, 16),
         ("cta", 256, 8),
@@ -324,7 +300,6 @@ def test_reg_roundtrip(scope, n_threads, k, dtype, non_r_scope):
 )
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 @pytest.mark.parametrize(
     "dtype", ["int8", "float8_e4m3fn", "float8_e5m2", "float16", "bfloat16", "float32"]
 )
@@ -363,16 +338,15 @@ def test_copy_g2l_l2g_vec_load(task, dtype):
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            np.testing.assert_allclose(B_ref, B.numpy())
+            np.testing.assert_allclose(B_ref.astype("float32"), B.numpy().astype("float32"))
 
         tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
-@MACA_XFAIL
 def test_reg_copy_wg_local_to_swizzled_shared_uses_swizzle_fastpath():
     """Regression: R→S copy where R has a ``wg_local_layout`` (thread iter
-    ``1 @ tid_in_wg``) must pick the widest vec PTX ``st.shared.v4`` AND use the
+    ``1 @ tid_in_wg``) must pick the widest MACA 128-bit copy intrinsic AND use the
     swizzle fast path (precomputed ``signed_strides`` + per-iter
     bit-select), not the per-iter ``swizzle.apply()`` fallback.
 
@@ -393,7 +367,7 @@ def test_reg_copy_wg_local_to_swizzled_shared_uses_swizzle_fastpath():
     """
     from tvm.tirx.layout import SwizzleLayout, wg_local_layout
 
-    N_THREADS, EPI_N = 128, 64
+    N_THREADS, EPI_N = 256, 64
     g_shape = (N_THREADS, EPI_N)
     g_layout = TileLayout(S[g_shape])
     # 128b swizzle on the SMEM side (per_element=3 ⇒ 8 fp16 atom width).
@@ -406,9 +380,14 @@ def test_reg_copy_wg_local_to_swizzled_shared_uses_swizzle_fastpath():
 
         T.device_entry()
         T.cta_id([1])
+        T.warpgroup_id([1])
+        T.warp_id_in_wg([4])
+        T.lane_id([64])
         T.thread_id([N_THREADS])
         tid = T.thread_id_in_wg([N_THREADS])
-        reg = T.alloc_buffer(g_shape, "float16", scope="local", layout=wg_local_layout(EPI_N))
+        reg = T.alloc_buffer(
+            g_shape, "float16", scope="local", layout=wg_local_layout(EPI_N, rows=N_THREADS)
+        )
         smem = T.alloc_buffer(g_shape, "float16", scope="shared", layout=smem_layout)
 
         # Populate the per-thread slice via .local() (decomposes the wg
@@ -416,8 +395,8 @@ def test_reg_copy_wg_local_to_swizzled_shared_uses_swizzle_fastpath():
         reg_local = reg.local(EPI_N)
         for i in T.serial(EPI_N):
             reg_local[i] = A[tid, i]
-        Tx.wg.copy(smem, reg)
-        T.cuda.cta_sync()
+        Tx.wg.copy(smem, reg, dispatch="reg")
+        T.maca.cta_sync()
         for i in T.serial(EPI_N):
             B[tid, i] = smem[tid, i]
 
@@ -427,14 +406,11 @@ def test_reg_copy_wg_local_to_swizzled_shared_uses_swizzle_fastpath():
         ex = tvm.compile(mod, target=target, tir_pipeline="tirx")
         src = ex.mod.imports[0].inspect_source()
 
-    # (1) Widest variant: 8 fp16 elements per call (16 bytes → v4.u32 st).
-    assert "tvm_builtin_ptx_st" in src, (
-        "expected PTX st in generated CUDA, alignment check fell back to a narrower variant"
+    # (1) Widest variant: 8 fp16 elements per call (16 bytes → copy_128b).
+    assert "tvm_builtin_copy_128b" in src, (
+        "expected MACA 128-bit copy, alignment check fell back to a narrower variant"
     )
-    assert "st.shared.v4" in src, "expected 128b vector store (st.shared.v4.u32)"
-    assert "tvm_builtin_copy_" not in src, (
-        "copy_xxb helpers appeared — reg dispatch should use PTX ld/st only"
-    )
+    assert "tvm_builtin_copy_16b" not in src, "expected a vectorized register copy"
     # (2) Swizzle fast path fingerprint:
     #   * emit_init allocates a size-N int buffer of "signed strides".
     #   * emit_iter_offset uses bit-select * signed-stride: ``(bit) * v[i]``
@@ -544,7 +520,7 @@ def test_reg_copy_tcgen05_d_epilogue_deposit_layout_pairing():
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
+@_TCGEN05_XFAIL
 def test_reg_copy_tcgen05_d_epilogue_deposit_codegen():
     """``reg`` dispatch lowers the D epilogue deposit; pre-fix loop only covered half.
 
@@ -624,7 +600,7 @@ def _build_tcgen05_d_epilogue_deposit_roundtrip():
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
+@_TCGEN05_XFAIL
 def test_reg_copy_tcgen05_d_epilogue_deposit_gpu():
     """GPU: R→S deposit + S→R reload must preserve the Layout-F register tile.
 


### PR DESCRIPTION
1. MACA groups four Wave64 warps into a 256-thread warpgroup, so the CUDA-derived copy lowering could not resolve warpgroup indices or dispatch fallback, gmem/smem, and register copies correctly.
2. Resolve the MACA warpgroup bindings and use fused thread and warp-in-group indices when checking active lanes and selecting copy offsets.
3. Update the copy tests and dispatch annotations for MACAgeometry, swizzled layouts, and the remaining low-precision and TCGEN05 expected failures.

Tests:
- Not run (commit message update only).