### PR TITLE
[TIRx][MACA] Support device function calls

### DIFF
--- a/src/backend/maca/codegen/codegen_maca.cc
+++ b/src/backend/maca/codegen/codegen_maca.cc
@@ -212,7 +212,20 @@ void CodeGenMACA::PreFunctionBody(const PrimFunc& f) {
   }
 }
 
-void CodeGenMACA::PrintFuncPrefix(std::ostream& os) { os << "extern \"C\" __global__ "; }
+void CodeGenMACA::PrintFunctionSignature(const ffi::String& function_name, const PrimFunc& func,
+                                         std::ostream& os) {
+  CallingConv calling_conv =
+      func->GetAttr<CallingConv>(tvm::attr::kCallingConv, CallingConv::kDefault).value();
+  if (calling_conv == CallingConv::kDeviceKernelLaunch) {
+    os << "extern \"C\" __global__ ";
+  } else if (calling_conv == CallingConv::kDefault) {
+    os << "extern \"C\" __device__ ";
+  } else {
+    TVM_FFI_THROW(InternalError) << "Unsupported calling convention for MACA codegen: "
+                                 << static_cast<int>(calling_conv);
+  }
+  CodeGenC::PrintFunctionSignature(function_name, func, os);
+}
 
 class ThreadIdxExtractor : public tirx::StmtVisitor {
  private:

--- a/src/backend/maca/codegen/codegen_maca.h
+++ b/src/backend/maca/codegen/codegen_maca.h
@@ -78,7 +78,8 @@ class CodeGenMACA final : public CodeGenC {
   }
   // override behavior
   void PreFunctionBody(const PrimFunc& f) final;
-  void PrintFuncPrefix(std::ostream& os) final;
+  void PrintFunctionSignature(const ffi::String& function_name, const PrimFunc& func,
+                              std::ostream& os) final;
   void PrintExtraAttrs(const PrimFunc& f, std::ostream& os) final;  // NOLINT(*)
   void VisitStmt_(const ForNode* op) final;
   void PrintStorageSync(const CallNode* op) final;

--- a/tests/python/codegen/test_target_codegen_cuda.py
+++ b/tests/python/codegen/test_target_codegen_cuda.py
@@ -1017,10 +1017,6 @@ extern "C" __global__ void __launch_bounds__(128) main_kernel(const __grid_const
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(
-    reason="TODO(maca): [device-function-call] lower private PrimFuncs as callable device functions instead of kernels",
-    strict=False,
-)
 def test_cuda_device_func_call():
     @I.ir_module(s_tir=True)
     class Module:
@@ -1065,10 +1061,6 @@ def test_cuda_float_const_hex_format():
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(
-    reason="TODO(maca): [host-device-call] support mixed host/device private function calls with MACA targets",
-    strict=False,
-)
 def test_device_host_call_same_func():
     @I.ir_module(s_tir=True)
     class Module:
@@ -1090,9 +1082,7 @@ def test_device_host_call_same_func():
     # 1. If we set host to llvm, it will raise an error of
     #    "Return should be transformed to return zero before LLVM code generation."
     #    Need to revisit this.
-    # 2. We set a dummy mcpu value for testing purpose,
-    #    in order to avoid checking a function is host or device based on the "cpu" substring.
-    target = tvm.target.Target({"kind": "maca", "mcpu": "dummy_mcpu"}, host="c")
+    target = tvm.target.Target({"kind": "maca"}, host="c")
     lib = tvm.compile(Module, target=target)
     cuda_code = lib.mod.imports[0].inspect_source()
     assert 'extern "C" __device__ int add(int a, int b) {\n  return (a + b);\n}' in cuda_code


### PR DESCRIPTION
- MACA emitted every generated function as a kernel, so private PrimFuncs with return values failed MACA compilation. Select __global__ or __device__ from the PrimFunc calling convention, matching the CUDA code generator.
- Remove the resolved xfail markers for device-only and mixed host/device calls.