### PR TITLE
[Relax] Support DefaultGPUSchedule with MACA target

### DIFF
--- a/tests/python/relax/test_frontend_nn_llm_sequence_prefill_masked.py
+++ b/tests/python/relax/test_frontend_nn_llm_sequence_prefill_masked.py
@@ -50,11 +50,6 @@ import tvm.testing
 from tvm.relax.frontend.nn.llm.kv_cache import _attention_sequence_prefill_with_mask
 from tvm.testing import env
 
-MACA_MASKED_PREFILL_XFAIL_REASON = (
-    "TODO(maca): [masked-prefill] support aligned shared-memory declarations emitted by "
-    "masked prefill codegen in the MACA compiler path"
-)
-
 
 def _reference_masked_attention(q, k, v, valid_lens, sm_scale):
     """Right-pad bidirectional reference. Only the first ``valid_lens[b]`` rows are written."""
@@ -192,17 +187,7 @@ def _run_case(
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 @pytest.mark.parametrize(
     "target",
-    [
-        pytest.param("cuda", marks=pytest.mark.gpu),
-        pytest.param(
-            "maca",
-            marks=[
-                pytest.mark.gpu,
-                pytest.mark.xfail(reason=MACA_MASKED_PREFILL_XFAIL_REASON, strict=False),
-            ],
-        ),
-        pytest.param("metal", marks=pytest.mark.gpu),
-    ],
+    [pytest.param("maca", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
 )
 def test_valid_len_zero(target):
     """All samples are fully padded: kernel must not crash and must stay bounded."""
@@ -225,17 +210,7 @@ def test_valid_len_zero(target):
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 @pytest.mark.parametrize(
     "target",
-    [
-        pytest.param("cuda", marks=pytest.mark.gpu),
-        pytest.param(
-            "maca",
-            marks=[
-                pytest.mark.gpu,
-                pytest.mark.xfail(reason=MACA_MASKED_PREFILL_XFAIL_REASON, strict=False),
-            ],
-        ),
-        pytest.param("metal", marks=pytest.mark.gpu),
-    ],
+    [pytest.param("maca", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
 )
 def test_valid_len_full(target):
     """All samples are fully valid: must match a plain unmasked attention."""
@@ -258,17 +233,7 @@ def test_valid_len_full(target):
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 @pytest.mark.parametrize(
     "target",
-    [
-        pytest.param("cuda", marks=pytest.mark.gpu),
-        pytest.param(
-            "maca",
-            marks=[
-                pytest.mark.gpu,
-                pytest.mark.xfail(reason=MACA_MASKED_PREFILL_XFAIL_REASON, strict=False),
-            ],
-        ),
-        pytest.param("metal", marks=pytest.mark.gpu),
-    ],
+    [pytest.param("maca", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
 )
 def test_valid_len_mixed(target):
     """Typical encoder batch with different valid lengths per sample."""
@@ -291,17 +256,7 @@ def test_valid_len_mixed(target):
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 @pytest.mark.parametrize(
     "target",
-    [
-        pytest.param("cuda", marks=pytest.mark.gpu),
-        pytest.param(
-            "maca",
-            marks=[
-                pytest.mark.gpu,
-                pytest.mark.xfail(reason=MACA_MASKED_PREFILL_XFAIL_REASON, strict=False),
-            ],
-        ),
-        pytest.param("metal", marks=pytest.mark.gpu),
-    ],
+    [pytest.param("maca", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
 )
 def test_valid_len_mixed_gqa(target):
     """Grouped-query attention: ``group_size = h_q / h_kv > 1``."""
@@ -324,17 +279,7 @@ def test_valid_len_mixed_gqa(target):
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 @pytest.mark.parametrize(
     "target",
-    [
-        pytest.param("cuda", marks=pytest.mark.gpu),
-        pytest.param(
-            "maca",
-            marks=[
-                pytest.mark.gpu,
-                pytest.mark.xfail(reason=MACA_MASKED_PREFILL_XFAIL_REASON, strict=False),
-            ],
-        ),
-        pytest.param("metal", marks=pytest.mark.gpu),
-    ],
+    [pytest.param("maca", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
 )
 def test_causal_padded_left_valid_len_zero(target):
     """Causal left-pad: all samples are fully padded."""
@@ -358,17 +303,7 @@ def test_causal_padded_left_valid_len_zero(target):
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 @pytest.mark.parametrize(
     "target",
-    [
-        pytest.param("cuda", marks=pytest.mark.gpu),
-        pytest.param(
-            "maca",
-            marks=[
-                pytest.mark.gpu,
-                pytest.mark.xfail(reason=MACA_MASKED_PREFILL_XFAIL_REASON, strict=False),
-            ],
-        ),
-        pytest.param("metal", marks=pytest.mark.gpu),
-    ],
+    [pytest.param("maca", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
 )
 def test_causal_padded_left_valid_len_full(target):
     """Causal left-pad: all samples are fully valid — degenerates to plain causal attention."""
@@ -392,17 +327,7 @@ def test_causal_padded_left_valid_len_full(target):
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 @pytest.mark.parametrize(
     "target",
-    [
-        pytest.param("cuda", marks=pytest.mark.gpu),
-        pytest.param(
-            "maca",
-            marks=[
-                pytest.mark.gpu,
-                pytest.mark.xfail(reason=MACA_MASKED_PREFILL_XFAIL_REASON, strict=False),
-            ],
-        ),
-        pytest.param("metal", marks=pytest.mark.gpu),
-    ],
+    [pytest.param("maca", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
 )
 def test_causal_padded_left_valid_len_mixed(target):
     """Causal left-pad: typical decoder-embedding batch with mixed lengths."""
@@ -426,17 +351,7 @@ def test_causal_padded_left_valid_len_mixed(target):
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 @pytest.mark.parametrize(
     "target",
-    [
-        pytest.param("cuda", marks=pytest.mark.gpu),
-        pytest.param(
-            "maca",
-            marks=[
-                pytest.mark.gpu,
-                pytest.mark.xfail(reason=MACA_MASKED_PREFILL_XFAIL_REASON, strict=False),
-            ],
-        ),
-        pytest.param("metal", marks=pytest.mark.gpu),
-    ],
+    [pytest.param("maca", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
 )
 def test_causal_padded_left_valid_len_mixed_gqa(target):
     """Causal left-pad: grouped-query attention with mixed lengths."""
@@ -460,17 +375,7 @@ def test_causal_padded_left_valid_len_mixed_gqa(target):
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 @pytest.mark.parametrize(
     "target",
-    [
-        pytest.param("cuda", marks=pytest.mark.gpu),
-        pytest.param(
-            "maca",
-            marks=[
-                pytest.mark.gpu,
-                pytest.mark.xfail(reason=MACA_MASKED_PREFILL_XFAIL_REASON, strict=False),
-            ],
-        ),
-        pytest.param("metal", marks=pytest.mark.gpu),
-    ],
+    [pytest.param("maca", marks=pytest.mark.gpu), pytest.param("metal", marks=pytest.mark.gpu)],
 )
 def test_causal_padded_left_qo_len_differs_from_kv_len(target):
     """Causal left-pad: Q and K/V may have different padded lengths."""

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -1128,7 +1128,7 @@ def test_sample_top_p_top_k_from_sorted_prob():
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 def test_renormalize_top_p_top_k_prob():
     prob_shape = (2, 3)
     sample_shape = (2, 1)


### PR DESCRIPTION
this PR fix following case files:
- tests/python/relax/test_frontend_nn_llm_sequence_prefill_masked.py;
- tests/python/relax/test_frontend_nn_op.py