### PR TITLE
[CI][MACA] set `USE_LLVM` to system absolute path to prevent accidental use of llvm-config in MACA SDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,7 @@ jobs:
           rm -rf build
           mkdir -p build
           cp cmake/config.cmake build
-          echo "set(USE_LLVM ON)" >> build/config.cmake
+          echo "set(USE_LLVM /usr/bin/llvm-config)" >> build/config.cmake
           echo "set(USE_MCBLAS ON)" >> build/config.cmake
           echo "set(USE_MCDNN ON)" >> build/config.cmake
           echo "set(USE_MCTLASS ON)" >> build/config.cmake


### PR DESCRIPTION
set `USE_LLVM` to system absolute path to prevent accidental use of llvm-config in MACA SDK