### PR TITLE
[Codegen][MACA] add software-based fp8_e8m0 support

### DIFF
--- a/src/backend/maca/codegen/codegen_maca.cc
+++ b/src/backend/maca/codegen/codegen_maca.cc
@@ -45,7 +45,8 @@ namespace maca {
 namespace {
 
 bool IsFloat8(const PrimType& type) {
-  return type.MatchesCode(DLDataTypeCode::kDLFloat8_e4m3fn, DLDataTypeCode::kDLFloat8_e5m2);
+  return type.MatchesCode(DLDataTypeCode::kDLFloat8_e4m3fn, DLDataTypeCode::kDLFloat8_e5m2,
+                          DLDataTypeCode::kDLFloat8_e8m0fnu);
 }
 
 bool IsFloat16(const PrimType& type) {
@@ -162,6 +163,10 @@ std::string GetFP8Type(const PrimType& type) {
     vec = "x16";
   } else {
     LOG(FATAL) << "Only support scalar and vector types of width (2, 4, 8, 16) for FP8";
+  }
+  if (type.MatchesCode(DLDataTypeCode::kDLFloat8_e8m0fnu)) {
+    stream << "fp8_e8" << vec << "_t";
+    return stream.str();
   }
   stream << "__maca_fp8";
   std::string suffix;
@@ -296,6 +301,54 @@ std::string CodeGenMACA::Finish() {
   if (enable_fp8_) {
     decl_stream << "#if defined(__MACA_ARCH__) && (__MACA_ARCH__ >= 1000)\n";
     decl_stream << "#include <maca_fp8.h>\n";
+    decl_stream << R"(
+__host__ __device__ unsigned char __tvm_cvt_float_to_e8m0(float value) {
+  unsigned int bits = *reinterpret_cast<unsigned int*>(&value);
+  unsigned int exponent = (bits >> 23) & 0xff;
+  unsigned int mantissa = bits & 0x7fffff;
+  if (mantissa >= 0x400000 && exponent < 0xff) {
+    ++exponent;
+  }
+  return static_cast<unsigned char>(exponent);
+}
+__host__ __device__ unsigned char __tvm_cvt_double_to_e8m0(double value) {
+  return __tvm_cvt_float_to_e8m0(static_cast<float>(value));
+}
+__host__ __device__ unsigned char __tvm_cvt_int_to_e8m0(int value) {
+  return value == 0 ? 0 : __tvm_cvt_float_to_e8m0(static_cast<float>(value < 0 ? -value : value));
+}
+struct fp8_e8_t {
+  unsigned char v;
+  __host__ __device__ fp8_e8_t() : v(0) {}
+  __host__ __device__ explicit fp8_e8_t(unsigned char value) : v(value) {}
+  __host__ __device__ explicit fp8_e8_t(float value) : v(__tvm_cvt_float_to_e8m0(value)) {}
+  __host__ __device__ explicit fp8_e8_t(double value) : v(__tvm_cvt_double_to_e8m0(value)) {}
+  __host__ __device__ explicit fp8_e8_t(int value) : v(__tvm_cvt_int_to_e8m0(value)) {}
+  __host__ __device__ operator unsigned char() const { return v; }
+  __host__ __device__ operator float() const {
+    unsigned int bits = static_cast<unsigned int>(v) << 23;
+    return *reinterpret_cast<float*>(&bits);
+  }
+};
+struct __align__(2) fp8_e8x2_t {
+  fp8_e8_t x, y;
+  __host__ __device__ fp8_e8x2_t(fp8_e8_t x, fp8_e8_t y) : x(x), y(y) {}
+  __host__ __device__ explicit fp8_e8x2_t(float2 value) : x(value.x), y(value.y) {}
+};
+struct __align__(4) fp8_e8x4_t {
+  fp8_e8_t x, y, z, w;
+  __host__ __device__ fp8_e8x4_t(fp8_e8_t x, fp8_e8_t y, fp8_e8_t z, fp8_e8_t w)
+      : x(x), y(y), z(z), w(w) {}
+  __host__ __device__ explicit fp8_e8x4_t(float4 value)
+      : x(value.x), y(value.y), z(value.z), w(value.w) {}
+};
+struct __align__(8) fp8_e8x8_t {
+  fp8_e8x4_t x, y;
+};
+struct __align__(16) fp8_e8x16_t {
+  fp8_e8x8_t x, y;
+};
+)";
     decl_stream << "using fp8_e4_t = __maca_fp8_e4m3;\n";
     decl_stream << "using fp8_e4x2_t = __maca_fp8x2_e4m3;\n";
     decl_stream << "using fp8_e4x4_t = __maca_fp8x4_e4m3;\n";
@@ -1008,6 +1061,28 @@ void CodeGenMACA::VisitExpr_(const CastNode* op, std::ostream& os) {
   PrimType from_ty = op->value.ty();
   PrimType target_ty = op->ty.as_or_throw<PrimType>();
   TVM_FFI_ICHECK_EQ(target_ty.lanes(), from_ty.lanes());
+
+  // MACA has no native e8m0 type.  Use TVM's helpers for the scalar and packed
+  // conversions supported here.
+  bool is_float32 = IsFloat(from_ty) && from_ty.bits() == 32;
+  if ((IsFloat16(from_ty) || is_float32) && IsFloat8(target_ty) && target_ty.lanes() <= 4) {
+    if (target_ty.MatchesCode(DLDataTypeCode::kDLFloat8_e8m0fnu)) {
+      enable_fp16_ = enable_fp16_ || IsFloat16(from_ty);
+      os << (is_float32 ? "cast_float_to_fp8_" : "cast_half_to_fp8_");
+      os << "e8m0";
+      os << "(" << PrintExpr(op->value) << ")";
+      return;
+    }
+  }
+
+  bool target_is_float32 = IsFloat(target_ty) && target_ty.bits() == 32;
+  if (from_ty.MatchesCode(DLDataTypeCode::kDLFloat8_e8m0fnu) &&
+      (IsFloat16(target_ty) || target_is_float32) && target_ty.lanes() <= 4) {
+    enable_fp16_ = enable_fp16_ || IsFloat16(target_ty);
+    os << (target_is_float32 ? "cast_fp8_e8m0_to_float(" : "cast_fp8_e8m0_to_half(");
+    os << PrintExpr(op->value) << ")";
+    return;
+  }
 
   // Emit simple C-style type conversion.
   if (from_ty.IsScalar()) return CodeGenC::VisitExpr_(op, os);

--- a/src/backend/maca/codegen/literal/maca_half_t.h
+++ b/src/backend/maca/codegen/literal/maca_half_t.h
@@ -394,7 +394,7 @@ struct __align__(8) half4_bfloat164 {
   __host__ __device__ half4_bfloat164() : x(T(0)), y(T(0)), z(T(0)), w(T(0)) {}
   __host__ __device__ half4_bfloat164(T x, T y, T z, T w) : x(x), y(y), z(z), w(w) {}
   __host__ __device__ half4_bfloat164(const __maca_fp8x4_e4m3& fp8x4) {
-    if constexpr (std::is_same_v<T, __half>) {
+    if constexpr (std::is_same<T, __half>::value) {
       __maca_fp8x2_e4m3 lo_part, hi_part;
       lo_part.__x = static_cast<__maca_fp8x2_storage_t>(fp8x4.__x & 0xFFFF);
       hi_part.__x = static_cast<__maca_fp8x2_storage_t>((fp8x4.__x >> 16) & 0xFFFF);
@@ -502,6 +502,57 @@ __host__ __device__ maca_bfloat162 cast_to_maca_bfloat162(const __maca_fp8x2_e4m
 }
       )";
     }
+  }
+  if (enable_fp8) {
+    stream << R"(
+__host__ __device__ fp8_e8_t cast_float_to_fp8_e8m0(float value) {
+    return fp8_e8_t(value);
+}
+__host__ __device__ fp8_e8x2_t cast_float_to_fp8_e8m0(float2 value) {
+    return fp8_e8x2_t{fp8_e8_t(value.x), fp8_e8_t(value.y)};
+}
+__host__ __device__ fp8_e8x4_t cast_float_to_fp8_e8m0(float4 value) {
+    return fp8_e8x4_t{fp8_e8_t(value.x), fp8_e8_t(value.y),
+                      fp8_e8_t(value.z), fp8_e8_t(value.w)};
+}
+__host__ __device__ float cast_fp8_e8m0_to_float(fp8_e8_t value) {
+    return static_cast<float>(value);
+}
+__host__ __device__ float2 cast_fp8_e8m0_to_float(fp8_e8x2_t value) {
+    return make_float2(static_cast<float>(value.x), static_cast<float>(value.y));
+}
+__host__ __device__ float4 cast_fp8_e8m0_to_float(fp8_e8x4_t value) {
+    return make_float4(static_cast<float>(value.x), static_cast<float>(value.y),
+                       static_cast<float>(value.z), static_cast<float>(value.w));
+}
+    )";
+  }
+  if (enable_fp16 && enable_fp8) {
+    stream << R"(
+__host__ __device__ fp8_e8_t cast_half_to_fp8_e8m0(__half value) {
+    return cast_float_to_fp8_e8m0(static_cast<float>(value));
+}
+__host__ __device__ fp8_e8x2_t cast_half_to_fp8_e8m0(__half2 value) {
+    return cast_float_to_fp8_e8m0(__half22float2(value));
+}
+__host__ __device__ fp8_e8x4_t cast_half_to_fp8_e8m0(half4 value) {
+    return cast_float_to_fp8_e8m0(make_float4(static_cast<float>(value.x),
+                                               static_cast<float>(value.y),
+                                               static_cast<float>(value.z),
+                                               static_cast<float>(value.w)));
+}
+__host__ __device__ __half cast_fp8_e8m0_to_half(fp8_e8_t value) {
+    return __float2half(cast_fp8_e8m0_to_float(value));
+}
+__host__ __device__ __half2 cast_fp8_e8m0_to_half(fp8_e8x2_t value) {
+    return __float22half2_rn(cast_fp8_e8m0_to_float(value));
+}
+__host__ __device__ half4 cast_fp8_e8m0_to_half(fp8_e8x4_t value) {
+    float4 converted = cast_fp8_e8m0_to_float(value);
+    return make_half4(__float2half(converted.x), __float2half(converted.y),
+                      __float2half(converted.z), __float2half(converted.w));
+}
+    )";
   }
   if (enable_fp8) {
     stream << R"(

--- a/tests/python/codegen/test_target_codegen_cuda_fp8.py
+++ b/tests/python/codegen/test_target_codegen_cuda_fp8.py
@@ -36,25 +36,22 @@ except ImportError:
     ml_dtypes = None
 
 
-FP8_MACA_XFAIL_REASON = (
-    "TODO(maca): [fp8] support FP8 datatype lowering, conversion, packing, and source expectations"
-)
+FP8_MACA_XFAIL_REASON = "TODO(maca): [fp8] fp16 to fp8 conversion results in precision loss"
 
 
 @pytest.mark.parametrize(
     "input",
     [
-        ("float8_e4m3fn", "__nv_fp8_e4m3"),
-        ("float8_e5m2", "__nv_fp8_e5m2"),
+        ("float8_e4m3fn", "__maca_fp8_e4m3"),
+        ("float8_e5m2", "__maca_fp8_e5m2"),
     ],
 )
+@pytest.mark.parametrize("promoted_dtype", ["float32", "float16"])
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(
-    reason="TODO(maca): [fp8] support FP8 source/type lowering compatible with these expectations",
-    strict=False,
-)
-def test_fp8_conversions(input):
+def test_fp8_conversions(input, promoted_dtype):
+    if "float16" in promoted_dtype:
+        pytest.xfail(FP8_MACA_XFAIL_REASON)
     dtype, nv_dtype = input
 
     def _create_mod(dtype):
@@ -74,7 +71,8 @@ def test_fp8_conversions(input):
                             T.reads(A[v_i], B[v_i])
                             T.writes(C[v_i])
                             C[v_i] = T.Cast(
-                                dtype, T.Cast("float16", A[v_i]) + T.Cast("float16", B[v_i])
+                                dtype,
+                                T.Cast(promoted_dtype, A[v_i]) + T.Cast(promoted_dtype, B[v_i]),
                             )
 
         return Module
@@ -94,7 +92,7 @@ def test_fp8_conversions(input):
     fadd(a, b, c)
 
     tvm.testing.assert_allclose(
-        c.numpy().astype("float16"), (a.numpy() + b.numpy()).astype("float16")
+        c.numpy().astype(promoted_dtype), (a.numpy() + b.numpy()).astype(promoted_dtype)
     )
 
 
@@ -105,8 +103,6 @@ def test_fp8_conversions(input):
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
 def test_fp8_packing(dtype):
-    if dtype == "float8_e8m0fnu":
-        pytest.skip("float8_e8m0fnu is not supported on MACA")
     length = 64
     vector_length = 4
     native_dtype, packed_dtype = (f"{dtype}x{vector_length}", "uint32")
@@ -169,12 +165,19 @@ def test_fp8_packing(dtype):
         ("float8_e5m2x2", "float16x2", "float8_e5m2"),
         ("float8_e5m2x4", "float32x4", "float8_e5m2"),
         ("float8_e5m2x4", "float16x4", "float8_e5m2"),
+        ("float8_e8m0fnu", "float32", "float8_e8m0fnu"),
+        ("float8_e8m0fnu", "float16", "float8_e8m0fnu"),
+        ("float8_e8m0fnux2", "float32x2", "float8_e8m0fnu"),
+        ("float8_e8m0fnux2", "float16x2", "float8_e8m0fnu"),
+        ("float8_e8m0fnux4", "float32x4", "float8_e8m0fnu"),
+        ("float8_e8m0fnux4", "float16x4", "float8_e8m0fnu"),
     ],
 )
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(reason=FP8_MACA_XFAIL_REASON, strict=False)
 def test_fp8_vector_conversions(native_dtype, promoted_dtype, numpytype):
+    if "float16" in promoted_dtype and ("e8m0fnu" not in native_dtype):
+        pytest.xfail(FP8_MACA_XFAIL_REASON)
     vector_length = 64
 
     def _create_mod(native_dtype, promoted_dtype):
@@ -810,10 +813,6 @@ class TestFP8e4x4QuantDequantScale(BaseFP8E4M3QuantScaleOnly):
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-    @pytest.mark.xfail(
-        reason="TODO(maca): [fp8] support FP8 quantize/dequantize schedules and runtime codegen",
-        strict=False,
-    )
     def test_main(self, weight_shape, model_dtype, target_str, compiled_functions):
         quant, dequant = compiled_functions
         dev = tvm.device(target_str, 0)
@@ -832,9 +831,6 @@ class TestFP8e4x4QuantDequantScale(BaseFP8E4M3QuantScaleOnly):
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
 @pytest.mark.parametrize("dtype", ["float8_e5m2", "float8_e4m3fn", "float8_e8m0fnu"])
 def test_const(dtype):
-    if dtype == "float8_e8m0fnu":
-        pytest.skip("float8_e8m0fnu is not supported on MACA")
-
     @T.prim_func(s_tir=True)
     def func(A: T.Buffer((4,), dtype)) -> None:
         A_local = T.sblock_alloc_buffer((4,), dtype=dtype, scope="local")
@@ -889,10 +885,6 @@ spatial_size = 4096
     reason="TODO(maca): [fp8] install ml_dtypes for FP8 GEMV verification",
     strict=False,
     run=False,
-)
-@pytest.mark.xfail(
-    reason="TODO(maca): [fp8] support FP8 GEMV lowering with shuffle-down scheduling",
-    strict=False,
 )
 def test_moe_gemv_shfl_down_illegal_instr():
     global num_experts
@@ -1006,10 +998,6 @@ def test_moe_gemv_shfl_down_illegal_instr():
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(
-    reason="TODO(maca): [fp8] support FP8 to FP16/BF16 vectorized arithmetic lowering",
-    strict=False,
-)
 def test_fp8_fp16_bf16_vectorize_arith(vec_length, dtype):
     def _create_mod(vec_length, dtype):
         num_threads = 128 // vec_length


### PR DESCRIPTION
Specifically,
- Added MACA e8m0 scalar/x2/x4 storage types and conversion helpers in src/backend/maca/codegen/codegen_maca.cc:301.
- Implemented nearest-power-of-two rounding with ties upward, matching ml_dtypes.
- Added bidirectional float32/float16 vector conversions in src/backend/maca/codegen/literal/maca_half_t.h:506.
- Routed e8m0 casts through those helpers and ensured required FP16 declarations are emitted.

fp8_{e4m3,e5m2} <-> fp32 conversions are automatically supported in MACA 3.9.0 and above.
fp8_{e4m3,e5m2} <-> fp16 are also supported, but the precision is low, so relevant tests are marked xfail.