### PR TITLE
[TIRx][MACA] Add tile reduction dispatch

### DIFF
--- a/python/tvm/backend/maca/script.py
+++ b/python/tvm/backend/maca/script.py
@@ -19,6 +19,8 @@
 from __future__ import annotations
 
 from tvm.backend.maca import op as _maca_op
+from tvm.tirx import is_buffer_var
+from tvm.tirx import op as _tir_op
 from tvm.tirx.script.builder.ir import _op_wrapper
 
 # pylint: disable=protected-access
@@ -38,6 +40,20 @@ class MACANamespace:
         self.copy_32b = _op_wrapper(_maca_op.maca_copy_32b)
         self.copy_16b = _op_wrapper(_maca_op.maca_copy_16b)
         self.copy_8b = _op_wrapper(_maca_op.maca_copy_8b)
+        setattr(self, "__activemask", self._activemask)
+        setattr(self, "__shfl_xor_sync", self._shfl_xor_sync)
+
+    @staticmethod
+    def _activemask():
+        return _tir_op.call_intrin("uint64", "tirx.maca.__activemask")
+
+    @staticmethod
+    def _shfl_xor_sync(mask, value, lane_mask, width):
+        if is_buffer_var(value):
+            value = value[0]
+        return _tir_op.call_intrin(
+            value.ty, "tirx.maca.__shfl_xor_sync", mask, value, lane_mask, width
+        )
 
 
 __all__ = ["MACANamespace"]

--- a/python/tvm/backend/maca/tile_primitive/layout_utils.py
+++ b/python/tvm/backend/maca/tile_primitive/layout_utils.py
@@ -16,8 +16,11 @@
 # under the License.
 """ComposeLayout helpers shared by MACA tile-primitive dispatches."""
 
+import functools
 import math
+import operator
 
+from tvm.arith import Analyzer
 from tvm.tirx.layout import ComposeLayout, S, TileLayout
 
 
@@ -58,3 +61,96 @@ def strip_swizzle_to_tile(layout, get_extents):
     if tile_size != layout_size:
         return TileLayout(S[tuple(extents)])
     return tile
+
+
+def get_sublayout_from_region(layout, buffer_shape, region_st, region_extent):
+    """Return the layout sliced to a buffer region when slicing succeeds."""
+    if not layout:
+        return layout
+    region = [(region_st[i], region_st[i] + region_extent[i]) for i in range(len(region_st))]
+    sliced = layout.slice(list(buffer_shape), region)
+    return sliced if sliced is not None else layout
+
+
+def get_local_region(orig_layout: TileLayout, buffer_shape, region_st, region_extent):
+    """Return storage-local shape, start, and extent for a contiguous region.
+
+    Thread-partitioned dimensions must be selected in full.  This gives local
+    tile-primitive emitters a physical-local view that matches a sliced layout.
+    """
+    grouped, seps = orig_layout.group(list(buffer_shape))
+    local_shape = []
+    local_st = []
+    local_ext = []
+    analyzer = Analyzer()
+
+    for dim in range(len(buffer_shape)):
+        shard_range = list(range(seps[dim], seps[dim + 1]))
+        has_local = any(not grouped.shard[index].axis.is_thread() for index in shard_range)
+        if not has_local:
+            continue
+
+        has_thread = any(grouped.shard[index].axis.is_thread() for index in shard_range)
+        if not has_thread:
+            local_shape.append(buffer_shape[dim])
+            local_st.append(region_st[dim])
+            local_ext.append(region_extent[dim])
+            continue
+
+        def decompose(value):
+            coords = []
+            remaining = value
+            for position, _ in enumerate(shard_range):
+                suffix_product = functools.reduce(
+                    operator.mul,
+                    [
+                        grouped.shard[shard_range[inner]].extent
+                        for inner in range(position + 1, len(shard_range))
+                    ],
+                    1,
+                )
+                coords.append(remaining // suffix_product)
+                remaining = remaining % suffix_product
+            return coords
+
+        start_coords = decompose(region_st[dim])
+        end_coords = decompose(region_st[dim] + region_extent[dim] - 1)
+        current_shape = 1
+        current_start = 0
+        current_end = 0
+        for position in reversed(range(len(start_coords))):
+            iterator = grouped.shard[seps[dim] + position]
+            if iterator.axis.is_thread():
+                if not (
+                    analyzer.can_prove_equal(start_coords[position], 0)
+                    and analyzer.can_prove_equal(end_coords[position], iterator.extent - 1)
+                ):
+                    return None
+                continue
+            spans_two_coords = analyzer.can_prove_equal(
+                end_coords[position] - start_coords[position], 1
+            )
+            selects_full_extent = analyzer.can_prove_equal(
+                start_coords[position], 0
+            ) and analyzer.can_prove_equal(end_coords[position], iterator.extent - 1)
+            if not spans_two_coords and not selects_full_extent:
+                return None
+            current_shape *= iterator.extent
+            current_start = current_start * iterator.extent + start_coords[position]
+            current_end = current_end * iterator.extent + end_coords[position]
+
+        assert analyzer.can_prove_equal(
+            region_extent[dim],
+            functools.reduce(
+                operator.mul,
+                [end - start + 1 for start, end in zip(start_coords, end_coords)],
+                1,
+            ),
+        )
+        local_shape.append(current_shape)
+        local_st.append(current_start)
+        local_ext.append(current_end - current_start + 1)
+
+    if not local_shape:
+        return [1], [0], [1]
+    return local_shape, local_st, local_ext

--- a/python/tvm/backend/maca/tile_primitive/reduction/__init__.py
+++ b/python/tvm/backend/maca/tile_primitive/reduction/__init__.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from .copy import *
-from .elementwise import *
-from .reduction import *
+"""MACA reduction tile-primitive dispatch registrations."""
+
+from .local import *
+from .shared import *

--- a/python/tvm/backend/maca/tile_primitive/reduction/local.py
+++ b/python/tvm/backend/maca/tile_primitive/reduction/local.py
@@ -1,0 +1,452 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Local-memory reduction dispatch for MACA GPUs.
+
+Thread scope performs a sequential reduction.  Warp scope additionally
+supports layout-driven local views and lane-sharded to replica Wave64 shuffle
+reductions.  Warpgroup reductions are not registered because they require a
+cross-wave reduction algorithm.
+"""
+
+import functools
+import operator
+from typing import Any
+
+from tvm.arith.analyzer import Analyzer
+from tvm.script import tirx as T
+from tvm.tirx import BufferRegion, PrimFunc, TilePrimitiveCall
+from tvm.tirx.layout import TileLayout, laneid
+from tvm.tirx.operator.tile_primitive import DispatchContext
+from tvm.tirx.operator.tile_primitive.common import ReduceOpType
+from tvm.tirx.operator.tile_primitive.dispatcher import predicate, register_dispatch
+
+from ..common import get_indices, get_st_extent
+from ..layout_utils import get_local_region, get_sublayout_from_region
+from .utils import (
+    _analyze_axes,
+    _analyze_layout_dims,
+    _build_local_dim_map,
+    _compute_shuffle_masks,
+    _match_reduction_storage_scope,
+    _reduction_args,
+    _validate_reduction_layout,
+    reduce_default_value_table,
+    reduce_op_table,
+    validate_wave64_shuffle_layout,
+)
+
+
+def _analyze_shuffle_reduce(src_layout, dst_layout):
+    """Recognize a full-Wave64 laneid-sharded to replicated reduction."""
+    if src_layout.is_swizzle() or dst_layout.is_swizzle():
+        return None
+
+    src_canonical = src_layout.canonicalize()
+    dst_canonical = dst_layout.canonicalize()
+    src_lane_shard = [iterator for iterator in src_canonical.shard if iterator.axis == laneid]
+    dst_lane_replica = [iterator for iterator in dst_canonical.replica if iterator.axis == laneid]
+    if not src_lane_shard or not dst_lane_replica:
+        return None
+
+    if any(
+        iterator.axis.is_thread() and iterator.axis != laneid for iterator in src_canonical.shard
+    ):
+        return None
+    if any(
+        iterator.axis.is_thread() and iterator.axis != laneid for iterator in dst_canonical.replica
+    ):
+        return None
+    try:
+        src_lane_iters = sorted(
+            ((int(iterator.stride), int(iterator.extent)) for iterator in src_lane_shard),
+        )
+        dst_lane_iters = sorted(
+            ((int(iterator.stride), int(iterator.extent)) for iterator in dst_lane_replica),
+        )
+    except (TypeError, ValueError):
+        return None
+
+    def is_full_wave(iters):
+        next_stride = 1
+        for stride, extent in iters:
+            if stride != next_stride or extent <= 0 or extent & (extent - 1):
+                return False
+            next_stride *= extent
+        return next_stride == 64
+
+    if not (is_full_wave(src_lane_iters) and is_full_wave(dst_lane_iters)):
+        return None
+    local_elems = functools.reduce(
+        operator.mul,
+        [int(iterator.extent) for iterator in src_canonical.shard if not iterator.axis.is_thread()],
+        1,
+    )
+    return 64, local_elems
+
+
+def _full_wave_active(sctx: DispatchContext) -> tuple[bool, str | None]:
+    """Require an unsliced Wave64 before emitting cross-lane shuffles."""
+    active_range = sctx.intra.get("laneid")
+    if active_range is None:
+        return False, "warp reduction is missing laneid active range"
+    if len(active_range) not in (2, 3):
+        return False, f"invalid laneid active range {active_range}"
+    try:
+        extent, offset = int(active_range[0]), int(active_range[1])
+        stride = int(active_range[2]) if len(active_range) == 3 else 1
+    except (TypeError, ValueError):
+        return False, f"non-static laneid active range {active_range}"
+    if (extent, offset, stride) != (64, 0, 1):
+        return False, f"Wave64 shuffle requires contiguous laneid [0, 64), got {active_range}"
+    return True, None
+
+
+def _is_full_buffer_region(buffer_region: BufferRegion) -> bool:
+    """Check whether a region covers every logical element of its buffer."""
+    buffer = buffer_region.buffer
+    if len(buffer_region.region) != len(buffer.shape):
+        return False
+    analyzer = Analyzer()
+    return all(
+        analyzer.can_prove_equal(region.min, 0) and analyzer.can_prove_equal(region.extent, shape)
+        for region, shape in zip(buffer_region.region, buffer.shape)
+    )
+
+
+def _can_use_shuffle_fast_path(src_br: BufferRegion, dst_br: BufferRegion) -> bool:
+    """The flat local shuffle emitter only supports full buffer regions."""
+    return _is_full_buffer_region(src_br) and _is_full_buffer_region(dst_br)
+
+
+def _emit_shuffle_reduce(
+    src, dst, reduce_width: int, local_elems: int, accum: bool, reduce_op: ReduceOpType
+) -> PrimFunc:
+    """Emit a MACA Wave64 XOR tree for each local storage value."""
+    op_func = reduce_op_table[reduce_op]
+    in_place = src.same_as(dst)
+    shuffle_count = reduce_width.bit_length() - 1
+
+    # fmt: off
+    @T.prim_func(check_well_formed=False)
+    def impl():
+        src_local = src.local(local_elems, layout=src.layout.storage())
+        dst_local = dst.local(local_elems, layout=dst.layout.storage())
+        old_value = T.alloc_buffer([1], dtype=src.dtype, scope="local")
+        for local_index in T.serial(local_elems):
+            if accum:
+                old_value[0] = dst_local[local_index]
+            if not in_place:
+                dst_local[local_index] = src_local[local_index]
+            active_mask = T.tvm_warp_activemask()
+            for bit in T.unroll(shuffle_count):
+                value = dst_local[local_index]
+                dst_local[local_index] = op_func(
+                    value,
+                    T.tvm_warp_shuffle_xor(active_mask, value, 1 << bit, reduce_width, 64),
+                )
+            if accum:
+                dst_local[local_index] = op_func(dst_local[local_index], old_value[0])
+    # fmt: on
+
+    return impl
+
+
+def validate_reduction_local(
+    op: TilePrimitiveCall, sctx: DispatchContext
+) -> tuple[bool, str | None]:
+    """Validate a thread- or warp-local MACA reduction."""
+    if not sctx.is_target("maca"):
+        return False, "expected MACA target"
+    op = TilePrimitiveCall.downcast(op)
+    dst_br, src_br = op.output, op.input
+    dst, src = dst_br.buffer, src_br.buffer
+    if not (src.scope() == "local" and dst.scope() == "local"):
+        return False, "expected local scope for both src and dst"
+    if src.dtype != dst.dtype:
+        return False, f"dtype mismatch: src={src.dtype} dst={dst.dtype}"
+    if sctx.is_thread:
+        return True, None
+    if not sctx.is_warp:
+        return False, f"unsupported exec_scope {sctx.scope_kind} for local reduction"
+    if not (src.layout and dst.layout):
+        return False, "layouts required for warp-local reduction"
+    if not (isinstance(src.layout, TileLayout) and isinstance(dst.layout, TileLayout)):
+        return False, "TileLayout required for warp-local reduction"
+    if src.layout.is_swizzle() or dst.layout.is_swizzle():
+        return False, "swizzle layout unsupported for local reduction"
+
+    try:
+        reduce_dims, _ = _analyze_axes(len(src_br.region), tuple(op.reduce_axes))
+    except AssertionError as error:
+        return False, str(error)
+
+    if (
+        _can_use_shuffle_fast_path(src_br, dst_br)
+        and _analyze_shuffle_reduce(src.layout, dst.layout) is not None
+    ):
+        return _full_wave_active(sctx)
+
+    if op.config.get("thread_reduce", False):
+        ok, reason = _full_wave_active(sctx)
+        if not ok:
+            return False, reason
+        ok, reason = validate_wave64_shuffle_layout(src.layout, src.shape, reduce_dims)
+        if not ok:
+            return False, reason
+
+    analyzer = Analyzer()
+    src_st, src_extent = get_st_extent(src_br)
+    dst_st, dst_extent = get_st_extent(dst_br)
+    for layout, buffer, start, extent, name in (
+        (src.layout, src, src_st, src_extent, "src"),
+        (dst.layout, dst, dst_st, dst_extent, "dst"),
+    ):
+        if any(
+            iterator.axis.is_thread() and analyzer.can_prove_equal(iterator.stride, 0)
+            for iterator in layout.shard
+        ):
+            return False, f"thread dimension with zero stride in {name}"
+        if any(iterator.axis.is_thread() for iterator in (getattr(layout, "replica", None) or [])):
+            return False, f"thread axis in replica for {name}"
+        if get_local_region(layout, list(buffer.shape), start, extent) is None:
+            return False, f"get_local_region failed for {name}"
+
+    src_sliced = get_sublayout_from_region(src.layout, src.shape, src_st, src_extent)
+    dst_sliced = get_sublayout_from_region(dst.layout, dst.shape, dst_st, dst_extent)
+    return _validate_reduction_layout(
+        src_sliced, dst_sliced, list(src_extent), list(dst_extent), reduce_dims
+    )
+
+
+def _emit_reduction_local_thread(
+    dst_br: BufferRegion,
+    src_br: BufferRegion,
+    accum: bool,
+    reduce_op: ReduceOpType,
+    reduce_dims: list[int],
+    spatial_dims: list[int],
+) -> PrimFunc:
+    dst, src = dst_br.buffer, src_br.buffer
+    src_st, src_extent = get_st_extent(src_br)
+    dst_st, dst_extent = get_st_extent(dst_br)
+    spatial_extents = [src_extent[dim] for dim in spatial_dims]
+    reduction_extents = [src_extent[dim] for dim in reduce_dims]
+    spatial_len = functools.reduce(operator.mul, spatial_extents, 1)
+    reduction_len = functools.reduce(operator.mul, reduction_extents, 1)
+    op_func = reduce_op_table[reduce_op]
+    init_value = reduce_default_value_table(src.dtype)[reduce_op]
+
+    def get_src_indices(spatial_fused, reduction_fused):
+        indices = [None] * len(src_extent)
+        remaining = spatial_fused
+        spatial_values = []
+        for extent in reversed(spatial_extents):
+            spatial_values.append(remaining % extent)
+            remaining //= extent
+        remaining = reduction_fused
+        reduction_values = []
+        for extent in reversed(reduction_extents):
+            reduction_values.append(remaining % extent)
+            remaining //= extent
+        for dim, value in zip(spatial_dims, reversed(spatial_values)):
+            indices[dim] = value + src_st[dim]
+        for dim, value in zip(reduce_dims, reversed(reduction_values)):
+            indices[dim] = value + src_st[dim]
+        return indices
+
+    # fmt: off
+    @T.prim_func(check_well_formed=False)
+    def impl():
+        for spatial_fused in T.serial(spatial_len):
+            dst_indices = T.meta_var(get_indices(spatial_fused, dst_st, dst_extent))
+            if not accum:
+                dst[tuple(dst_indices)] = init_value
+            for reduction_fused in T.serial(reduction_len):
+                src_indices = T.meta_var(get_src_indices(spatial_fused, reduction_fused))
+                dst[tuple(dst_indices)] = op_func(
+                    dst[tuple(dst_indices)], src[tuple(src_indices)]
+                )
+    # fmt: on
+
+    return impl
+
+
+def _emit_reduction_local_view(
+    dst_br: BufferRegion,
+    src_br: BufferRegion,
+    accum: bool,
+    reduce_op: ReduceOpType,
+    config: dict[str, Any],
+    reduce_dims: list[int],
+    src_local_info,
+    dst_local_info,
+    shuffle_masks: list[int],
+) -> PrimFunc:
+    dst, src = dst_br.buffer, src_br.buffer
+    src_local_shape, src_local_st, src_local_extent = src_local_info
+    dst_local_shape, dst_local_st, dst_local_extent = dst_local_info
+    src_dim_map = _build_local_dim_map(src.layout, list(src.shape))
+    dst_dim_map = _build_local_dim_map(dst.layout, list(dst.shape))
+    local_reduce_dims = [dim for dim in reduce_dims if src_dim_map[dim] is not None]
+    local_reduce_extent = [src_local_extent[src_dim_map[dim]] for dim in local_reduce_dims]
+    local_reduce_start = [src_local_st[src_dim_map[dim]] for dim in local_reduce_dims]
+    local_reduce_total = functools.reduce(operator.mul, local_reduce_extent, 1)
+    dst_local_total = functools.reduce(operator.mul, dst_local_extent, 1)
+    op_func = reduce_op_table[reduce_op]
+    init_value = reduce_default_value_table(src.dtype)[reduce_op]
+    shuffle = bool(config.get("thread_reduce", False))
+    in_place = dst.same_as(src)
+
+    def get_src_local_indices(dst_fused, reduction_fused):
+        dst_indices = get_indices(dst_fused, dst_local_st, dst_local_extent)
+        reduction_indices = get_indices(reduction_fused, local_reduce_start, local_reduce_extent)
+        indices = []
+        reduction_position = 0
+        for dim in range(len(src_br.region)):
+            if src_dim_map[dim] is None:
+                continue
+            if dim in reduce_dims:
+                indices.append(reduction_indices[reduction_position])
+                reduction_position += 1
+            else:
+                indices.append(dst_indices[dst_dim_map[dim]])
+        return indices
+
+    def shuffle_value(active_mask, dst_local, dst_indices):
+        @T.inline
+        def shuffle_once(value, xor_mask):
+            dst_local[tuple(dst_indices)] = op_func(
+                value, T.tvm_warp_shuffle_xor(active_mask, value, xor_mask, 64, 64)
+            )
+
+        for xor_mask in shuffle_masks:
+            shuffle_once(dst_local[tuple(dst_indices)], xor_mask)
+
+    save_accum = accum and shuffle
+
+    # fmt: off
+    if save_accum:
+        @T.prim_func(check_well_formed=False)
+        def impl():
+            src_local = src.local(*src_local_shape, layout=src.layout.storage())
+            dst_local = dst.local(*dst_local_shape, layout=dst.layout.storage())
+            old_value = T.alloc_buffer([1], dtype=src.dtype, scope="local")
+            for spatial_fused in T.serial(dst_local_total):
+                dst_indices = T.meta_var(get_indices(spatial_fused, dst_local_st, dst_local_extent))
+                old_value[0] = dst_local[tuple(dst_indices)]
+                if not in_place:
+                    dst_local[tuple(dst_indices)] = init_value
+                    for reduction_fused in T.serial(local_reduce_total):
+                        src_indices = T.meta_var(
+                            get_src_local_indices(spatial_fused, reduction_fused)
+                        )
+                        dst_local[tuple(dst_indices)] = op_func(
+                            dst_local[tuple(dst_indices)], src_local[tuple(src_indices)]
+                        )
+                active_mask = T.tvm_warp_activemask()
+                shuffle_value(active_mask, dst_local, dst_indices)
+                dst_local[tuple(dst_indices)] = op_func(
+                    dst_local[tuple(dst_indices)], old_value[0]
+                )
+    else:
+        @T.prim_func(check_well_formed=False)
+        def impl():
+            src_local = src.local(*src_local_shape, layout=src.layout.storage())
+            dst_local = dst.local(*dst_local_shape, layout=dst.layout.storage())
+            for spatial_fused in T.serial(dst_local_total):
+                dst_indices = T.meta_var(get_indices(spatial_fused, dst_local_st, dst_local_extent))
+                if not in_place:
+                    if not accum:
+                        dst_local[tuple(dst_indices)] = init_value
+                    for reduction_fused in T.serial(local_reduce_total):
+                        src_indices = T.meta_var(
+                            get_src_local_indices(spatial_fused, reduction_fused)
+                        )
+                        dst_local[tuple(dst_indices)] = op_func(
+                            dst_local[tuple(dst_indices)], src_local[tuple(src_indices)]
+                        )
+                if shuffle:
+                    active_mask = T.tvm_warp_activemask()
+                    shuffle_value(active_mask, dst_local, dst_indices)
+    # fmt: on
+
+    return impl
+
+
+def reduction_local_impl(
+    op: TilePrimitiveCall, op_type: ReduceOpType, sctx: DispatchContext
+) -> PrimFunc:
+    dst_br, src_br, reduce_axes, accum, config = _reduction_args(op)
+    reduce_dims, spatial_dims = _analyze_axes(len(src_br.region), reduce_axes)
+    if sctx.is_thread:
+        return _emit_reduction_local_thread(
+            dst_br, src_br, accum, op_type, reduce_dims, spatial_dims
+        )
+
+    src, dst = src_br.buffer, dst_br.buffer
+    shuffle_info = (
+        _analyze_shuffle_reduce(src.layout, dst.layout)
+        if _can_use_shuffle_fast_path(src_br, dst_br)
+        else None
+    )
+    if shuffle_info is not None:
+        return _emit_shuffle_reduce(src, dst, *shuffle_info, accum, op_type)
+
+    src_st, src_extent = get_st_extent(src_br)
+    dst_st, dst_extent = get_st_extent(dst_br)
+    src_local_info = get_local_region(src.layout, list(src.shape), src_st, src_extent)
+    dst_local_info = get_local_region(dst.layout, list(dst.shape), dst_st, dst_extent)
+    assert src_local_info is not None and dst_local_info is not None
+    shuffle_masks = (
+        _compute_shuffle_masks(_analyze_layout_dims(src.layout, list(src.shape)), set(reduce_dims))
+        if config.get("thread_reduce", False)
+        else []
+    )
+    return _emit_reduction_local_view(
+        dst_br,
+        src_br,
+        accum,
+        op_type,
+        config,
+        reduce_dims,
+        src_local_info,
+        dst_local_info,
+        shuffle_masks,
+    )
+
+
+for _op_name, _op_type in (
+    ("sum", ReduceOpType.SUM),
+    ("max", ReduceOpType.MAX),
+    ("min", ReduceOpType.MIN),
+):
+
+    @register_dispatch(
+        _op_name,
+        "maca",
+        variant="local",
+        priority=10,
+        when=[
+            predicate("storage_scope", _match_reduction_storage_scope, expected_scope=["local"]),
+            predicate("local_valid", validate_reduction_local),
+        ],
+    )
+    def _local_dispatch(
+        op: TilePrimitiveCall, sctx: DispatchContext, _reduce_op=_op_type
+    ) -> PrimFunc:
+        return reduction_local_impl(TilePrimitiveCall.downcast(op), _reduce_op, sctx)

--- a/python/tvm/backend/maca/tile_primitive/reduction/shared.py
+++ b/python/tvm/backend/maca/tile_primitive/reduction/shared.py
@@ -1,0 +1,253 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Shared-memory reduction dispatch for MACA GPUs.
+
+CTA and warp scopes use a Wave64 XOR-shuffle tree.  Thread scope uses a
+sequential local reduction.  Warpgroup reductions are intentionally excluded:
+their cross-wave synchronization needs a separate implementation.
+"""
+
+import functools
+import math
+import operator
+
+from tvm.arith.analyzer import Analyzer
+from tvm.script import tirx as T
+from tvm.tirx import BufferRegion, PrimFunc, TilePrimitiveCall
+from tvm.tirx.operator.tile_primitive import DispatchContext, fail
+from tvm.tirx.operator.tile_primitive.common import ReduceOpType
+from tvm.tirx.operator.tile_primitive.dispatcher import predicate, register_dispatch
+
+from ..common import get_indices, get_st_extent, next_power_of_2
+from .utils import (
+    _analyze_axes,
+    _match_reduction_storage_scope,
+    _reduction_args,
+    build_src_indices,
+    reduce_default_value_table,
+    reduce_op_table,
+)
+
+
+def validate_reduction_shared(
+    op: TilePrimitiveCall, sctx: DispatchContext
+) -> tuple[bool, str | None]:
+    """Validate a shared-memory reduction that MACA can execute."""
+    if not sctx.is_target("maca"):
+        return False, "expected MACA target"
+    if sctx.scope_kind not in ("cta", "warp", "thread"):
+        return False, f"unsupported exec_scope {sctx.scope_kind} for shared reduction"
+
+    op = TilePrimitiveCall.downcast(op)
+    dst, src = op.output.buffer, op.input.buffer
+    if not (src.scope().startswith("shared") and dst.scope().startswith("shared")):
+        return False, "expected shared scope for both src and dst"
+    if src.dtype != dst.dtype:
+        return False, f"dtype mismatch: src={src.dtype} dst={dst.dtype}"
+    if "threadIdx.x" not in sctx.launch_params:
+        return False, "threadIdx.x not in launch_params"
+    if "threadIdx.y" in sctx.launch_params or "threadIdx.z" in sctx.launch_params:
+        return False, "multi-dimensional thread binding not supported for shared reduction"
+    if sctx.scope_kind == "cta":
+        try:
+            thread_count = int(sctx.launch_params["threadIdx.x"].dom.extent)
+        except (TypeError, ValueError):
+            return False, "CTA shared reduction requires a static threadIdx.x extent"
+        if thread_count <= 0 or thread_count % 64:
+            return (
+                False,
+                f"CTA shared reduction requires a multiple of 64 threads, got {thread_count}",
+            )
+
+    try:
+        reduce_dims, spatial_dims = _analyze_axes(len(op.input.region), tuple(op.reduce_axes))
+    except AssertionError as error:
+        return False, str(error)
+
+    src_extent = [region.extent for region in op.input.region]
+    dst_extent = [region.extent for region in op.output.region]
+    expected_dst_len = functools.reduce(operator.mul, [src_extent[dim] for dim in spatial_dims], 1)
+    actual_dst_len = functools.reduce(operator.mul, dst_extent, 1)
+    if not Analyzer().can_prove_equal(expected_dst_len, actual_dst_len):
+        return False, f"dst size {actual_dst_len} != expected spatial size {expected_dst_len}"
+    return True, None
+
+
+def _emit_reduction_shared_wave(
+    dst_br: BufferRegion,
+    src_br: BufferRegion,
+    accum: bool,
+    reduce_op: ReduceOpType,
+    sctx: DispatchContext,
+    reduce_dims: list[int],
+    spatial_dims: list[int],
+) -> PrimFunc:
+    scope_kind = sctx.scope_kind
+    thread_count = sctx.launch_params["threadIdx.x"].dom.extent if scope_kind == "cta" else 64
+    dst, src = dst_br.buffer, src_br.buffer
+    src_st, src_extent = get_st_extent(src_br)
+    dst_st, dst_extent = get_st_extent(dst_br)
+    spatial_len = functools.reduce(operator.mul, [src_extent[dim] for dim in spatial_dims], 1)
+    reduction_len = functools.reduce(operator.mul, [src_extent[dim] for dim in reduce_dims], 1)
+    op_func = reduce_op_table[reduce_op]
+    init_value = reduce_default_value_table(src.dtype)[reduce_op]
+
+    group_size = min(next_power_of_2(int(reduction_len)), 64)
+    shuffle_count = int(math.log2(group_size)) if group_size > 1 else 0
+    spatial_parallelism = int(thread_count) // group_size
+
+    def get_tid_in_scope():
+        thread_idx = sctx.launch_params["threadIdx.x"].var
+        return thread_idx if scope_kind == "cta" else thread_idx % 64
+
+    def shuffle_data(thread_data):
+        @T.inline
+        def shuffle_once(mask, value, xor_mask):
+            value[0] = op_func(
+                value[0], T.tvm_warp_shuffle_xor(mask, value[0], xor_mask, group_size, 64)
+            )
+
+        if shuffle_count:
+            active_mask = T.tvm_warp_activemask()
+            for bit in range(shuffle_count):
+                shuffle_once(active_mask, thread_data, 1 << bit)
+
+    @T.inline
+    def sync():
+        if scope_kind == "cta":
+            T.maca.cta_sync()
+        else:
+            T.maca.warp_sync()
+
+    # fmt: off
+    @T.prim_func
+    def impl():
+        tid_in_scope = get_tid_in_scope()
+        thread_data = T.alloc_buffer([1], dtype=src.dtype, scope="local")
+        group_id = T.meta_var(T.floordiv(tid_in_scope, group_size))
+        lane_in_group = T.meta_var(tid_in_scope % group_size)
+        for step in T.serial(T.ceildiv(spatial_len, spatial_parallelism)):
+            spatial_fused = T.meta_var(step * spatial_parallelism + group_id)
+            if spatial_fused < spatial_len:
+                thread_data[0] = init_value
+                for tile in T.serial(T.ceildiv(reduction_len, group_size)):
+                    reduction_fused = T.meta_var(tile * group_size + lane_in_group)
+                    if reduction_fused < reduction_len:
+                        src_indices = T.meta_var(
+                            build_src_indices(
+                                spatial_fused,
+                                reduction_fused,
+                                spatial_dims,
+                                reduce_dims,
+                                src_extent,
+                                src_st,
+                            )
+                        )
+                        thread_data[0] = op_func(thread_data[0], src[tuple(src_indices)])
+                shuffle_data(thread_data)
+                if lane_in_group == 0:
+                    dst_indices = T.meta_var(get_indices(spatial_fused, dst_st, dst_extent))
+                    dst[tuple(dst_indices)] = T.if_then_else(
+                        T.bool(accum),
+                        op_func(dst[tuple(dst_indices)], thread_data[0]),
+                        thread_data[0],
+                    )
+        sync()
+    # fmt: on
+
+    return impl
+
+
+def _emit_reduction_shared_thread(
+    dst_br: BufferRegion,
+    src_br: BufferRegion,
+    accum: bool,
+    reduce_op: ReduceOpType,
+    reduce_dims: list[int],
+    spatial_dims: list[int],
+) -> PrimFunc:
+    dst, src = dst_br.buffer, src_br.buffer
+    src_st, src_extent = get_st_extent(src_br)
+    dst_st, dst_extent = get_st_extent(dst_br)
+    spatial_len = functools.reduce(operator.mul, [src_extent[dim] for dim in spatial_dims], 1)
+    reduction_len = functools.reduce(operator.mul, [src_extent[dim] for dim in reduce_dims], 1)
+    op_func = reduce_op_table[reduce_op]
+    init_value = reduce_default_value_table(src.dtype)[reduce_op]
+
+    # fmt: off
+    @T.prim_func
+    def impl():
+        for spatial_fused in T.serial(spatial_len):
+            dst_indices = T.meta_var(get_indices(spatial_fused, dst_st, dst_extent))
+            if not accum:
+                dst[tuple(dst_indices)] = init_value
+            for reduction_fused in T.serial(reduction_len):
+                src_indices = T.meta_var(
+                    build_src_indices(
+                        spatial_fused,
+                        reduction_fused,
+                        spatial_dims,
+                        reduce_dims,
+                        src_extent,
+                        src_st,
+                    )
+                )
+                dst[tuple(dst_indices)] = op_func(
+                    dst[tuple(dst_indices)], src[tuple(src_indices)]
+                )
+    # fmt: on
+
+    return impl
+
+
+def reduction_shared_impl(
+    op: TilePrimitiveCall, op_type: ReduceOpType, sctx: DispatchContext
+) -> PrimFunc:
+    dst_br, src_br, reduce_axes, accum, _ = _reduction_args(op)
+    reduce_dims, spatial_dims = _analyze_axes(len(src_br.region), reduce_axes)
+    if sctx.scope_kind in ("cta", "warp"):
+        return _emit_reduction_shared_wave(
+            dst_br, src_br, accum, op_type, sctx, reduce_dims, spatial_dims
+        )
+    if sctx.is_thread:
+        return _emit_reduction_shared_thread(
+            dst_br, src_br, accum, op_type, reduce_dims, spatial_dims
+        )
+    fail(f"unsupported exec_scope {sctx.scope_kind} for shared reduction")
+
+
+for _op_name, _op_type in (
+    ("sum", ReduceOpType.SUM),
+    ("max", ReduceOpType.MAX),
+    ("min", ReduceOpType.MIN),
+):
+
+    @register_dispatch(
+        _op_name,
+        "maca",
+        variant="shared",
+        priority=10,
+        when=[
+            predicate("storage_scope", _match_reduction_storage_scope, expected_scope=["shared*"]),
+            predicate("shared_valid", validate_reduction_shared),
+        ],
+    )
+    def _shared_dispatch(
+        op: TilePrimitiveCall, sctx: DispatchContext, _reduce_op=_op_type
+    ) -> PrimFunc:
+        return reduction_shared_impl(TilePrimitiveCall.downcast(op), _reduce_op, sctx)

--- a/python/tvm/backend/maca/tile_primitive/reduction/utils.py
+++ b/python/tvm/backend/maca/tile_primitive/reduction/utils.py
@@ -1,0 +1,223 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Shared helpers for MACA reduction tile-primitive dispatches."""
+
+import math
+
+from tvm.arith.analyzer import Analyzer
+from tvm.script import tirx as T
+from tvm.tirx import BufferRegion, TilePrimitiveCall
+from tvm.tirx.layout import laneid
+from tvm.tirx.operator.tile_primitive import DispatchContext
+from tvm.tirx.operator.tile_primitive.common import ReduceOpType
+
+from ..common import match_scope
+
+reduce_op_table = {
+    ReduceOpType.SUM: lambda a, b: a + b,
+    ReduceOpType.MAX: T.max,
+    ReduceOpType.MIN: T.min,
+}
+
+
+def reduce_default_value_table(dtype):
+    return {
+        ReduceOpType.SUM: 0.0,
+        ReduceOpType.MAX: T.min_value(dtype),
+        ReduceOpType.MIN: T.max_value(dtype),
+    }
+
+
+def _reduction_args(
+    op: TilePrimitiveCall,
+) -> tuple[BufferRegion, BufferRegion, tuple[int, ...], bool, dict]:
+    """Parse a ReduceOp tile primitive."""
+    op = TilePrimitiveCall.downcast(op)
+    return op.output, op.input, tuple(int(axis) for axis in op.reduce_axes), op.accum, op.config
+
+
+def _match_reduction_storage_scope(
+    op: TilePrimitiveCall, sctx: DispatchContext, expected_scope: list[str]
+) -> tuple[bool, str | None]:
+    """Check that source and destination match one accepted storage scope."""
+    op = TilePrimitiveCall.downcast(op)
+    dst_scope = op.output.buffer.scope()
+    src_scope = op.input.buffer.scope()
+    ok = any(
+        match_scope(dst_scope, pattern) and match_scope(src_scope, pattern)
+        for pattern in expected_scope
+    )
+    message = f"storage scope mismatch: dst {dst_scope}, src {src_scope}; expected {expected_scope}"
+    return ok, None if ok else message
+
+
+def _analyze_axes(src_ndim: int, reduce_axes: tuple[int, ...]) -> tuple[list[int], list[int]]:
+    """Normalize reduction axes and return reduction and spatial dimensions."""
+    reduce_dims = set()
+    for axis in reduce_axes:
+        normalized = axis if axis >= 0 else axis + src_ndim
+        assert 0 <= normalized < src_ndim, f"reduce axis {axis} out of range for ndim={src_ndim}"
+        reduce_dims.add(normalized)
+    return sorted(reduce_dims), [dim for dim in range(src_ndim) if dim not in reduce_dims]
+
+
+def _analyze_layout_dims(layout, shape):
+    """Split each logical layout dimension into thread and local parts."""
+    grouped, seps = layout.group(list(shape))
+    result = []
+    for dim in range(len(shape)):
+        thread_extent = 1
+        local_extent = 1
+        thread_strides = []
+        for index in range(seps[dim], seps[dim + 1]):
+            iterator = grouped.shard[index]
+            if iterator.axis.is_thread():
+                thread_extent *= iterator.extent
+                thread_strides.append((iterator.stride, iterator.extent))
+            else:
+                local_extent *= iterator.extent
+        result.append((thread_extent, local_extent, thread_strides))
+    return result
+
+
+def _compute_shuffle_masks(dim_info, reduce_dims: set[int]) -> list[int]:
+    """Derive XOR masks for power-of-two thread dimensions being reduced."""
+    masks = []
+    for dim in reduce_dims:
+        _, _, thread_strides = dim_info[dim]
+        for stride, extent in thread_strides:
+            for bit in range(int(math.log2(int(extent)))):
+                masks.append(int(stride) * (1 << bit))
+    return sorted(masks)
+
+
+def _is_power_of_two(value: int) -> bool:
+    return value > 0 and value & (value - 1) == 0
+
+
+def validate_wave64_shuffle_layout(
+    layout, shape, reduce_dims: list[int]
+) -> tuple[bool, str | None]:
+    """Validate a full-Wave64 layout that can use XOR shuffle reduction."""
+    try:
+        grouped, seps = layout.group(list(shape))
+    except Exception as error:  # pragma: no cover - layout FFI diagnostics
+        return False, f"failed to group layout: {error}"
+
+    masks = []
+    for dim in reduce_dims:
+        for index in range(seps[dim], seps[dim + 1]):
+            iterator = grouped.shard[index]
+            if not iterator.axis.is_thread():
+                continue
+            if iterator.axis != laneid:
+                return False, "thread_reduce only supports laneid-partitioned reductions"
+            try:
+                extent = int(iterator.extent)
+                stride = int(iterator.stride)
+            except (TypeError, ValueError):
+                return False, "thread_reduce requires static laneid layout"
+            if not _is_power_of_two(extent):
+                return False, f"laneid extent {extent} is not a power of two"
+            masks.extend(stride * (1 << bit) for bit in range(extent.bit_length() - 1))
+
+    if not masks:
+        return True, None
+    if any(mask <= 0 or mask >= 64 or not _is_power_of_two(mask) for mask in masks):
+        return False, f"invalid Wave64 XOR masks {sorted(masks)}"
+    if len(set(masks)) != len(masks):
+        return False, f"duplicate Wave64 XOR masks {sorted(masks)}"
+    return True, None
+
+
+def _build_local_dim_map(layout, buffer_shape):
+    """Map logical dimensions to positions in a storage-local view."""
+    grouped, seps = layout.group(list(buffer_shape))
+    dim_map = {}
+    local_position = 0
+    for dim in range(len(buffer_shape)):
+        has_local = any(
+            not grouped.shard[index].axis.is_thread() for index in range(seps[dim], seps[dim + 1])
+        )
+        dim_map[dim] = local_position if has_local else None
+        if has_local:
+            local_position += 1
+    return dim_map
+
+
+def _validate_reduction_layout(
+    src_layout, dst_layout, src_shape, dst_shape, reduce_dims: list[int]
+) -> tuple[bool, str | None]:
+    """Validate compatible thread/local partitions for a local reduction."""
+    src_info = _analyze_layout_dims(src_layout, src_shape)
+    dst_info = _analyze_layout_dims(dst_layout, dst_shape)
+    analyzer = Analyzer()
+    expected_dst = []
+    for src_dim, (thread_extent, local_extent, _) in enumerate(src_info):
+        if analyzer.can_prove_equal(thread_extent, 1) and analyzer.can_prove_equal(local_extent, 1):
+            continue
+        if src_dim in reduce_dims:
+            if not analyzer.can_prove_equal(thread_extent, 1):
+                expected_dst.append((thread_extent, 1))
+        else:
+            expected_dst.append((thread_extent, local_extent))
+
+    expected_index = 0
+    for thread_extent, local_extent, _ in dst_info:
+        if analyzer.can_prove_equal(thread_extent, 1) and analyzer.can_prove_equal(local_extent, 1):
+            continue
+        if expected_index == len(expected_dst):
+            return False, "mismatch dst/src layout for reduction"
+        expected_thread, expected_local = expected_dst[expected_index]
+        if not (
+            analyzer.can_prove_equal(thread_extent, expected_thread)
+            and analyzer.can_prove_equal(local_extent, expected_local)
+        ):
+            return False, "mismatch dst/src layout for reduction"
+        expected_index += 1
+    if expected_index != len(expected_dst):
+        return False, "mismatch dst/src layout for reduction"
+    return True, None
+
+
+def build_src_indices(
+    spatial_fused, reduction_fused, spatial_dims, reduce_dims, src_extent, src_st
+):
+    """Combine fused spatial and reduction indices into source coordinates."""
+
+    def unfuse(fused, dims):
+        values = []
+        remaining = fused
+        for extent in reversed([src_extent[dim] for dim in dims]):
+            values.append(remaining % extent)
+            remaining //= extent
+        return list(reversed(values))
+
+    indices = [None] * len(src_extent)
+    for dim, value in zip(spatial_dims, unfuse(spatial_fused, spatial_dims)):
+        indices[dim] = value + src_st[dim]
+    for dim, value in zip(reduce_dims, unfuse(reduction_fused, reduce_dims)):
+        indices[dim] = value + src_st[dim]
+    return indices
+
+
+_REDUCE_OP_TO_STR = {
+    ReduceOpType.SUM: "sum",
+    ReduceOpType.MAX: "max",
+    ReduceOpType.MIN: "min",
+}

--- a/python/tvm/tirx/op.py
+++ b/python/tvm/tirx/op.py
@@ -908,14 +908,14 @@ def tvm_warp_shuffle_xor(mask, value, lane_mask, width, warp_size):
 
 
 def tvm_warp_activemask():
-    """Return a 32-bit mask indicates currently active threads in a calling warp.
+    """Return a 64-bit mask indicating active threads in a calling warp.
 
     Returns
     -------
     call : Expr
         The call expression.
     """
-    return call_intrin("uint32", "tirx.tvm_warp_activemask")
+    return call_intrin("uint64", "tirx.tvm_warp_activemask")
 
 
 def type_annotation(dtype):

--- a/tests/python/tirx/operator/tile_primitive/cuda/reduction/test_reduction.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/reduction/test_reduction.py
@@ -25,7 +25,7 @@ from tvm.testing import env
 from tvm.tirx.layout import R, S, TileLayout, laneid, wg_local_layout
 
 MACA_XFAIL = pytest.mark.xfail(
-    reason="TODO(maca): [tile-primitive-reduction] support reduction dispatch variants",
+    reason="TODO(maca): [tile-primitive-reduction] unsupported reduction scope or layout",
     strict=False,
 )
 
@@ -49,7 +49,6 @@ MACA_XFAIL = pytest.mark.xfail(
 )
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 @pytest.mark.parametrize("op_type", ["sum", "max", "min"])
 @pytest.mark.parametrize("dtype", ["float32", "float16"])
 @pytest.mark.parametrize("accum", [False, True])
@@ -58,7 +57,7 @@ def test_reduction_shared(
 ):
     ndim_src = len(src_shape)
 
-    thread_cnt = 32
+    thread_cnt = 64
     if np.prod(src_shape) > 1024:
         thread_cnt = 128
 
@@ -88,14 +87,14 @@ def test_reduction_shared(
         Tx.cta.copy(A_smem[tuple(copy_slice_src)], A[tuple(copy_slice_src)])
         if accum:
             Tx.cta.copy(B_smem[tuple(copy_slice_dst)], B[tuple(copy_slice_dst)])
-        T.cuda.cta_sync()
+        T.maca.cta_sync()
         if op_type == "sum":
             Tx.cta.sum(B_smem[tuple(reduce_slice_dst)], A_smem[tuple(reduce_slice_src)], axes=axes, accum=accum) # noqa: E501
         elif op_type == "max":
             Tx.cta.max(B_smem[tuple(reduce_slice_dst)], A_smem[tuple(reduce_slice_src)], axes=axes, accum=accum) # noqa: E501
         elif op_type == "min":
             Tx.cta.min(B_smem[tuple(reduce_slice_dst)], A_smem[tuple(reduce_slice_src)], axes=axes, accum=accum) # noqa: E501
-        T.cuda.cta_sync()
+        T.maca.cta_sync()
         Tx.cta.copy(B[tuple(copy_slice_dst)], B_smem[tuple(copy_slice_dst)])
         # fmt: on
 
@@ -143,8 +142,10 @@ def test_reduction_shared(
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
-@pytest.mark.parametrize("exec_scope", ["warp", "warpgroup", "thread"])
+@pytest.mark.parametrize(
+    "exec_scope",
+    ["warp", pytest.param("warpgroup", marks=MACA_XFAIL), "thread"],
+)
 @pytest.mark.parametrize("op_type", ["sum", "max", "min"])
 @pytest.mark.parametrize("accum", [False, True])
 def test_reduction_shared_subscope(exec_scope, op_type, accum):
@@ -164,7 +165,7 @@ def test_reduction_shared_subscope(exec_scope, op_type, accum):
             A = T.match_buffer(A_ptr, src_shape, dtype, layout=g_layout_src)
             B = T.match_buffer(B_ptr, dst_shape, dtype, layout=g_layout_dst)
             T.device_entry()
-            warp_id = T.warp_id([(256) // 32])
+            warp_id = T.warp_id([(256) // 64])
             _bx = T.cta_id([1])
             _tid = T.thread_id([256])
             A_smem = T.alloc_buffer(list(src_shape), dtype, scope="shared", layout=s_layout_src)
@@ -172,15 +173,15 @@ def test_reduction_shared_subscope(exec_scope, op_type, accum):
             Tx.cta.copy(A_smem, A)
             if accum:
                 Tx.cta.copy(B_smem, B)
-            T.cuda.cta_sync()
-            if warp_id == 5:
+            T.maca.cta_sync()
+            if warp_id == 2:
                 if op_type == "sum":
                     Tx.warp.sum(B_smem, A_smem, axes=axes, accum=accum)
                 elif op_type == "max":
                     Tx.warp.max(B_smem, A_smem, axes=axes, accum=accum)
                 elif op_type == "min":
                     Tx.warp.min(B_smem, A_smem, axes=axes, accum=accum)
-            T.cuda.cta_sync()
+            T.maca.cta_sync()
             Tx.cta.copy(B, B_smem)
     elif exec_scope == "warpgroup":
         @T.prim_func
@@ -196,7 +197,7 @@ def test_reduction_shared_subscope(exec_scope, op_type, accum):
             Tx.cta.copy(A_smem, A)
             if accum:
                 Tx.cta.copy(B_smem, B)
-            T.cuda.cta_sync()
+            T.maca.cta_sync()
             if wg_id == 0:
                 if op_type == "sum":
                     Tx.wg.sum(B_smem, A_smem, axes=axes, accum=accum)
@@ -204,7 +205,7 @@ def test_reduction_shared_subscope(exec_scope, op_type, accum):
                     Tx.wg.max(B_smem, A_smem, axes=axes, accum=accum)
                 elif op_type == "min":
                     Tx.wg.min(B_smem, A_smem, axes=axes, accum=accum)
-            T.cuda.cta_sync()
+            T.maca.cta_sync()
             Tx.cta.copy(B, B_smem)
     elif exec_scope == "thread":
         @T.prim_func
@@ -219,7 +220,7 @@ def test_reduction_shared_subscope(exec_scope, op_type, accum):
             Tx.cta.copy(A_smem, A)
             if accum:
                 Tx.cta.copy(B_smem, B)
-            T.cuda.cta_sync()
+            T.maca.cta_sync()
             if _tid == 65:
                 if op_type == "sum":
                     Tx.sum(B_smem, A_smem, axes=axes, accum=accum)
@@ -227,7 +228,7 @@ def test_reduction_shared_subscope(exec_scope, op_type, accum):
                     Tx.max(B_smem, A_smem, axes=axes, accum=accum)
                 elif op_type == "min":
                     Tx.min(B_smem, A_smem, axes=axes, accum=accum)
-            T.cuda.cta_sync()
+            T.maca.cta_sync()
             Tx.cta.copy(B, B_smem)
         # fmt: on
 
@@ -283,7 +284,6 @@ def test_reduction_shared_subscope(exec_scope, op_type, accum):
 )
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 @pytest.mark.parametrize("op_type", ["sum", "max", "min"])
 @pytest.mark.parametrize("accum", [False, True])
 def test_reduction_local_thread_wise(src_shape, dst_shape, axes, op_type, accum):
@@ -391,15 +391,14 @@ def test_reduction_local_thread_wise(src_shape, dst_shape, axes, op_type, accum)
 )
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 @pytest.mark.parametrize("op_type", ["sum", "max", "min"])
 def test_reduction_local_view_basic(inner_dims, dst_dims, axes, accum, slice_end, op_type):
     """Test view-based local reduction with simple purely-local layouts."""
     dtype = "float32"
-    thread_cnt = 32
+    thread_cnt = 64
 
-    src_shape = (32, *inner_dims)
-    dst_shape = (32, *dst_dims)
+    src_shape = (thread_cnt, *inner_dims)
+    dst_shape = (thread_cnt, *dst_dims)
 
     def row_major_strides(dims):
         strides = []
@@ -506,33 +505,30 @@ def test_reduction_local_view_basic(inner_dims, dst_dims, axes, accum, slice_end
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np.copy(), dev)
             mod(A, B)
-            tvm.testing.assert_allclose(ref, B.numpy(), atol=1e-5)
+            atol = 2e-5 if op_type == "sum" else 1e-5
+            tvm.testing.assert_allclose(ref, B.numpy(), atol=atol)
 
         tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 @pytest.mark.parametrize("n_groups, n_warps", [(1, 1), (1, 4), (2, 8)])
 @pytest.mark.parametrize("op_type", ["sum", "max", "min"])
 @pytest.mark.parametrize("dtype", ["float32", "float16"])
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("accum", [False, True])
 def test_reduction_local_view_complex(n_groups, n_warps, op_type, dtype, shuffle, accum):
-    """Test view-based local reduction with wgmma layouts and optional shuffle."""
+    """Test view-based local reduction with Wave64 layouts and optional shuffle."""
     if not shuffle and accum:
-        pytest.xfail(
-            "TODO(maca): [tile-primitive-reduction] support accum reductions without "
-            "shuffle in local-view reduction"
-        )
-    thread_cnt = 32
+        pytest.skip("accum without shuffle is not supported in current implementation")
+    thread_cnt = 64
     NUM_COL = 128
     g_shape_a = (16 * n_warps, NUM_COL)
-    g_shape_b = (16 * n_warps, 4)
+    g_shape_b = (16 * n_warps, 8)
     g_layout_a = TileLayout(S[g_shape_a])
     g_layout_b = TileLayout(S[g_shape_b])
-    acc_shape, red_shape = (16, NUM_COL), (16, 4)
+    acc_shape, red_shape = (16, NUM_COL), (16, 8)
 
     # fmt: off
     @T.prim_func
@@ -545,44 +541,45 @@ def test_reduction_local_view_complex(n_groups, n_warps, op_type, dtype, shuffle
         wg_id = T.warpgroup_id([n_groups])
         warp_id_in_wg = T.warp_id_in_wg([n_warps // n_groups])
         lane_id = T.lane_id([thread_cnt])
-                # acc layout
+
+        # Accumulator layout
         atom = T.TileLayout(T.S[(1, 2) : (2, 1)])
-        warp_layout = T.TileLayout(T.S[(8, 4) : (4@laneid, 1@laneid)])
-        warp_atom = atom.tile(warp_layout, (8, 4), (1, 2))
-        tile = T.TileLayout(T.S[(2, NUM_COL // 8) : (1, 2)])
-        acc_layout = warp_atom.tile(tile, (2, NUM_COL // 8), (8, 8))
+        warp_layout = T.TileLayout(T.S[(8, 8) : (8@laneid, 1@laneid)])
+        warp_atom = atom.tile(warp_layout, (8, 8), (1, 2))
+        tile = T.TileLayout(T.S[(2, NUM_COL // 16) : (1, 2)])
+        acc_layout = warp_atom.tile(tile, (2, NUM_COL // 16), (8, 16))
         acc = T.alloc_buffer(
-            [2, NUM_COL // 4],
+            [2, NUM_COL // 8],
             dtype=dtype,
             scope="local",
-            layout=atom.tile(tile, (2, NUM_COL // 8), (1, 2)),
+            layout=atom.tile(tile, (2, NUM_COL // 16), (1, 2)),
         )
 
-                # red layout
+        # red layout
         red_atom = T.TileLayout(T.S[(1, 1) : (1, 1)])
-        red_warp_atom = red_atom.tile(warp_layout, (8, 4), (1, 1))
+        red_warp_atom = red_atom.tile(warp_layout, (8, 8), (1, 1))
         red_tile = T.TileLayout(T.S[(2, 1) : (1, 1)])
-        red_layout = red_warp_atom.tile(red_tile, (2, 1), (8, 4))
+        red_layout = red_warp_atom.tile(red_tile, (2, 1), (8, 8))
         red = T.alloc_buffer(
             [2],
             dtype=dtype,
             scope="local",
             layout=red_atom.tile(red_tile, (2, 1), (1, 1)),
         )
-        for i in T.serial(NUM_COL // 8):
+        for i in T.serial(NUM_COL // 16):
             for j in T.unroll(2):
                 for vec in T.vectorized(2):
                     acc[j, i * 2 + vec] = A[
-                        wg_id * 64 + warp_id_in_wg * 16 + j * 8 + lane_id // 4,
-                        i * 8 + lane_id % 4 * 2 + vec,
+                        wg_id * 64 + warp_id_in_wg * 16 + j * 8 + lane_id // 8,
+                        i * 16 + lane_id % 8 * 2 + vec,
                     ]
 
-            # Pre-load B into red for accumulation
+        # Pre-load B into red for accumulation.
         if accum:
             for i in T.unroll(2):
                 red[i] = B[
-                    wg_id * 64 + warp_id_in_wg * 16 + i * 8 + lane_id // 4,
-                    lane_id % 4,
+                    wg_id * 64 + warp_id_in_wg * 16 + i * 8 + lane_id // 8,
+                    lane_id % 8,
                 ]
         acc_view = acc.view(*acc_shape, layout=acc_layout)
         red_view = red.view(*red_shape, layout=red_layout)
@@ -592,7 +589,6 @@ def test_reduction_local_view_complex(n_groups, n_warps, op_type, dtype, shuffle
             Tx.warp.max(red_view, acc_view, thread_reduce=shuffle, accum=accum)
         elif op_type == "min":
             Tx.warp.min(red_view, acc_view, thread_reduce=shuffle, accum=accum)
-                # perform an additional shuffle step if not shuffled above
         if not shuffle:
             if op_type == "sum":
                 Tx.warp.sum(red_view, red_view, thread_reduce=True)
@@ -600,9 +596,9 @@ def test_reduction_local_view_complex(n_groups, n_warps, op_type, dtype, shuffle
                 Tx.warp.max(red_view, red_view, thread_reduce=True)
             elif op_type == "min":
                 Tx.warp.min(red_view, red_view, thread_reduce=True)
-            # Write red into B
+        # Write red into B
         for i in T.unroll(2):
-            B[wg_id * 64 + warp_id_in_wg * 16 + i * 8 + lane_id // 4, lane_id % 4] = (
+            B[wg_id * 64 + warp_id_in_wg * 16 + i * 8 + lane_id // 8, lane_id % 8] = (
                 red[i]
             )
 
@@ -622,21 +618,21 @@ def test_reduction_local_view_complex(n_groups, n_warps, op_type, dtype, shuffle
         if op_type == "sum":
             row_reduce = A_np.sum(axis=-1)
             if accum:
-                B_ref = np.tile(row_reduce[:, np.newaxis], (1, 4)) + B_np
+                B_ref = np.tile(row_reduce[:, np.newaxis], (1, 8)) + B_np
             else:
-                B_ref = np.tile(row_reduce[:, np.newaxis], (1, 4))
+                B_ref = np.tile(row_reduce[:, np.newaxis], (1, 8))
         elif op_type == "max":
             row_reduce = A_np.max(axis=-1)
             if accum:
-                B_ref = np.maximum(np.tile(row_reduce[:, np.newaxis], (1, 4)), B_np)
+                B_ref = np.maximum(np.tile(row_reduce[:, np.newaxis], (1, 8)), B_np)
             else:
-                B_ref = np.tile(row_reduce[:, np.newaxis], (1, 4))
+                B_ref = np.tile(row_reduce[:, np.newaxis], (1, 8))
         elif op_type == "min":
             row_reduce = A_np.min(axis=-1)
             if accum:
-                B_ref = np.minimum(np.tile(row_reduce[:, np.newaxis], (1, 4)), B_np)
+                B_ref = np.minimum(np.tile(row_reduce[:, np.newaxis], (1, 8)), B_np)
             else:
-                B_ref = np.tile(row_reduce[:, np.newaxis], (1, 4))
+                B_ref = np.tile(row_reduce[:, np.newaxis], (1, 8))
         else:
             raise ValueError(f"Unsupported op_type: {op_type}")
 
@@ -654,12 +650,11 @@ def test_reduction_local_view_complex(n_groups, n_warps, op_type, dtype, shuffle
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 @pytest.mark.parametrize("reduction_len", [8, 16, 64, 128, 256, 7, 10, 15, 100])
 @pytest.mark.parametrize("op_type", ["max", "min"])
 @pytest.mark.parametrize("accum", [False, True])
 def test_reduction_local_optimized_3input_maxmin(reduction_len, op_type, accum):
-    """Test thread-level local buffer reduction with 3-input max/min PTX intrinsics."""
+    """Test generic thread-level local buffer max/min reduction."""
     dtype = "float32"
 
     # fmt: off
@@ -728,11 +723,10 @@ def test_reduction_local_optimized_3input_maxmin(reduction_len, op_type, accum):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 @pytest.mark.parametrize("reduction_len", [8, 16, 64, 128, 256, 9, 17, 63, 65, 100])
 @pytest.mark.parametrize("accum", [False, True])
 def test_reduction_local_optimized_packed_add_sum(reduction_len, accum):
-    """Test thread-level sum reduction using packed add with add.f32x2 PTX instruction."""
+    """Test generic thread-level local buffer sum reduction."""
     dtype = "float32"
 
     # fmt: off
@@ -762,8 +756,7 @@ def test_reduction_local_optimized_packed_add_sum(reduction_len, accum):
         B[0] = B_local[0]
         # fmt: on
 
-        # Use sm_100a target for packed add sum dispatch
-    target = tvm.target.Target({"kind": "maca", "arch": "sm_100a"})
+    target = tvm.target.Target("maca")
     with target:
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
@@ -781,7 +774,6 @@ def test_reduction_local_optimized_packed_add_sum(reduction_len, accum):
         else:
             B_ref = A_np.sum()
 
-        # Use larger tolerance due to rounding differences from packed add (add.rz.ftz.f32x2)
         def run_and_check():
             dev = tvm.maca(0)
             A = tvm.runtime.tensor(A_np, dev)
@@ -794,21 +786,20 @@ def test_reduction_local_optimized_packed_add_sum(reduction_len, accum):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 @pytest.mark.parametrize("op_type", ["sum", "max"])
 @pytest.mark.parametrize("dtype", ["float32", "float16"])
 def test_reduction_op_warp_shuffle(op_type, dtype):
     """Test warp-scope shuffle reduce with laneid shard→replica layout pattern.
 
-    Case A: full warp reduce (32 lanes → 1 value, replicated to all lanes).
+    Covers MACA's Wave64 wavefront.
     """
-    N = 32
+    N = 64
     g_shape = (N,)
     g_layout = TileLayout(S[N])
 
-    # src layout: 32 elements sharded across 32 lanes
+    # src layout: one element sharded across every participating lane
     src_layout = TileLayout(S[N : 1 @ laneid])
-    # dst layout: 1 element replicated across 32 lanes
+    # dst layout: one element replicated across every participating lane
     dst_layout = TileLayout(S[1:1] + R[N : 1 @ laneid])
 
     # fmt: off
@@ -820,7 +811,7 @@ def test_reduction_op_warp_shuffle(op_type, dtype):
         T.device_entry()
         cta_id = T.cta_id([1])
         warp_id = T.warp_id([1])
-        lane_id = T.lane_id([32])
+        lane_id = T.lane_id([N])
         src_local = T.alloc_buffer([1], dtype, scope="local")
         dst_local = T.alloc_buffer([1], dtype, scope="local")
         src_local[0] = A[lane_id]
@@ -861,24 +852,23 @@ def test_reduction_op_warp_shuffle(op_type, dtype):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@MACA_XFAIL
 @pytest.mark.parametrize("op_type", ["sum", "max"])
 @pytest.mark.parametrize("dtype", ["float32", "float16"])
 def test_reduction_op_warp_shuffle_multi_elem(op_type, dtype):
     """Test warp-scope shuffle reduce with multiple elements per thread.
 
-    Each thread holds 4 elements, reduce across 32 lanes for each element group.
+    Each thread holds four elements, reduced across MACA's Wave64 wavefront.
     """
     ELEMS_PER_THREAD = 4
-    N_LANES = 32
-    TOTAL = ELEMS_PER_THREAD * N_LANES  # 128
+    N_LANES = 64
+    TOTAL = ELEMS_PER_THREAD * N_LANES
     g_shape = (TOTAL,)
     g_layout = TileLayout(S[TOTAL])
 
-    # src: 32 lanes with 4 elements each; layout S[(32, 4) : (1@laneid, 1)]
+    # src: lanes with four elements each; layout S[(lanes, 4) : (1@laneid, 1)]
     # element (i, j) → lane i, local j → thread k holds [4k, 4k+1, 4k+2, 4k+3]
     src_layout = TileLayout(S[(N_LANES, ELEMS_PER_THREAD) : (1 @ laneid, 1)])
-    # dst: 4 elements per thread, replicated across 32 lanes
+    # dst: four elements per thread, replicated across every participating lane
     dst_layout = TileLayout(S[ELEMS_PER_THREAD:1] + R[N_LANES : 1 @ laneid])
 
     # fmt: off
@@ -891,7 +881,7 @@ def test_reduction_op_warp_shuffle_multi_elem(op_type, dtype):
         T.device_entry()
         cta_id = T.cta_id([1])
         warp_id = T.warp_id([1])
-        lane_id = T.lane_id([32])
+        lane_id = T.lane_id([N_LANES])
         src_local = T.alloc_buffer([ELEMS_PER_THREAD], dtype, scope="local")
         dst_local = T.alloc_buffer([ELEMS_PER_THREAD], dtype, scope="local")
         for i in T.serial(ELEMS_PER_THREAD):
@@ -914,7 +904,7 @@ def test_reduction_op_warp_shuffle_multi_elem(op_type, dtype):
         np.random.seed(0)
         A_np = np.random.rand(TOTAL).astype(dtype)
         B_np = np.zeros(ELEMS_PER_THREAD, dtype=dtype)
-        # Each group of 4 elements: element j is sum/max of A[j], A[j+4], A[j+8], ..., A[j+124]
+        # Element j reduces A[j], A[j + 4], ... across all participating lanes.
         A_reshaped = A_np.reshape(N_LANES, ELEMS_PER_THREAD)
         if op_type == "sum":
             B_ref = A_reshaped.astype("float64").sum(axis=0).astype(dtype)


### PR DESCRIPTION
Add shared- and local-memory reduction dispatches for MACA tile
primitives. The local path supports layout-driven reductions and guarded
Wave64 shuffle trees, while the shared path handles thread, warp, and CTA
scopes.

Align active-mask typing with the 64-lane execution model and update the
reduction coverage, including the complex local-view accumulation path.
