### PR TITLE
[Chore] Fallback unsupported PTX TIR tests to upstream state

### DIFF
--- a/tests/python/tirx-base/test_tir_ptx_cp_async.py
+++ b/tests/python/tirx-base/test_tir_ptx_cp_async.py
@@ -23,10 +23,6 @@ import tvm.testing
 from tvm.script import tirx as T
 from tvm.testing import env
 
-MACA_PTX_CP_ASYNC_XFAIL_REASON = (
-    "TODO(maca): [ptx-cp-async] support PTX cp.async legacy, commit_group, and wait_group lowering"
-)
-
 
 @T.prim_func(s_tir=True)
 def ptx_cp_async(A: T.Buffer((32, 128), "float16"), B: T.Buffer((32, 128), "float16")) -> None:
@@ -56,17 +52,16 @@ def ptx_cp_async(A: T.Buffer((32, 128), "float16"), B: T.Buffer((32, 128), "floa
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(reason=MACA_PTX_CP_ASYNC_XFAIL_REASON, strict=False)
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_ptx_cp_async():
     f = ptx_cp_async
 
-    mod = tvm.compile(f, target="maca")
+    mod = tvm.compile(f, target="cuda")
     A_np = np.random.rand(32, 128).astype("float16")
     B_np = np.zeros((32, 128)).astype("float16")
 
     def run_and_check():
-        dev = tvm.maca(0)
+        dev = tvm.cuda(0)
         A_nd = tvm.runtime.tensor(A_np, device=dev)
         B_nd = tvm.runtime.tensor(B_np, device=dev)
         mod(A_nd, B_nd)

--- a/tests/python/tirx-base/test_tir_ptx_griddepcontrol.py
+++ b/tests/python/tirx-base/test_tir_ptx_griddepcontrol.py
@@ -23,11 +23,6 @@ import tvm.testing
 from tvm.script import tirx as T
 from tvm.testing import env
 
-MACA_PTX_GRIDDEPCONTROL_XFAIL_REASON = (
-    "TODO(maca): [ptx-griddepcontrol] support PTX grid dependency control wait and "
-    "launch_dependents lowering"
-)
-
 
 @T.prim_func(s_tir=True)
 def ptx_griddepcontrol(A: T.Buffer((32,), "float32"), B: T.Buffer((32,), "float32")) -> None:
@@ -45,16 +40,15 @@ def ptx_griddepcontrol(A: T.Buffer((32,), "float32"), B: T.Buffer((32,), "float3
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(reason=MACA_PTX_GRIDDEPCONTROL_XFAIL_REASON, strict=False)
+@pytest.mark.skipif(not env.has_cuda_compute(9), reason="need cuda compute >= 9.0")
 def test_ptx_griddepcontrol():
     f = ptx_griddepcontrol
-    mod = tvm.compile(f, target="maca")
+    mod = tvm.compile(f, target="cuda")
     A_np = np.random.default_rng(0).standard_normal(32).astype("float32")
     B_np = np.zeros((32,), dtype="float32")
 
     def run_and_check():
-        dev = tvm.maca(0)
+        dev = tvm.cuda(0)
         A_nd = tvm.runtime.tensor(A_np, device=dev)
         B_nd = tvm.runtime.tensor(B_np, device=dev)
         mod(A_nd, B_nd)

--- a/tests/python/tirx-base/test_tir_ptx_ldmatrix.py
+++ b/tests/python/tirx-base/test_tir_ptx_ldmatrix.py
@@ -23,10 +23,6 @@ import tvm.testing
 from tvm.script import tirx as T
 from tvm.testing import env
 
-MACA_PTX_LDMATRIX_XFAIL_REASON = (
-    "TODO(maca): [ptx-ldmatrix] support PTX legacy ldmatrix lowering for shared-memory matrix loads"
-)
-
 
 @T.prim_func(s_tir=True)
 def ptx_ldmatrix(
@@ -64,15 +60,14 @@ def ptx_ldmatrix(
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(reason=MACA_PTX_LDMATRIX_XFAIL_REASON, strict=False)
+@pytest.mark.skipif(not env.has_cuda_compute(7, 5), reason="need cuda compute >= 7.5")
 def test_ptx_ldmatrix():
     f = ptx_ldmatrix
     _, _, param_num, param_trans = f.params
 
     for num in [1, 2, 4]:
         for trans in [False, True]:
-            mod = tvm.compile(f.specialize({param_num: num, param_trans: trans}), target="maca")
+            mod = tvm.compile(f.specialize({param_num: num, param_trans: trans}), target="cuda")
             A_np = np.random.rand(16, 16).astype("float16")
             A_mask_np = np.zeros_like(A_np)
             if num == 1:
@@ -97,7 +92,7 @@ def test_ptx_ldmatrix():
             B_np = np.zeros((16, 16)).astype("float16")
 
             def run_and_check():
-                dev = tvm.maca(0)
+                dev = tvm.cuda(0)
                 A_nd = tvm.runtime.tensor(A_np, device=dev)
                 B_nd = tvm.runtime.tensor(B_np, device=dev)
                 mod(A_nd, B_nd)

--- a/tests/python/tirx-base/test_tir_ptx_mma.py
+++ b/tests/python/tirx-base/test_tir_ptx_mma.py
@@ -23,12 +23,6 @@ import tvm.testing
 from tvm.script import tirx as T
 from tvm.testing import env
 
-MACA_PTX_MMA_XFAIL_REASON = (
-    "TODO(maca): [ptx-mma] support PTX legacy MMA lowering across fp, int, sub-byte, and bit modes"
-)
-
-pytestmark = pytest.mark.xfail(reason=MACA_PTX_MMA_XFAIL_REASON, strict=False)
-
 
 @T.prim_func(s_tir=True)
 def gemm_mma_m8n8k4_row_col_fp64pf64fp64(a: T.handle, b: T.handle, c: T.handle):
@@ -73,10 +67,10 @@ def gemm_mma_m8n8k4_row_col_fp64pf64fp64(a: T.handle, b: T.handle, c: T.handle):
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_gemm_mma_m8n8k4_row_col_fp64pf64fp64():
     sch = tvm.s_tir.Schedule(gemm_mma_m8n8k4_row_col_fp64pf64fp64)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-1, 1, [8, 4]).astype("float64")
     B_np = np.random.uniform(-1, 1, [8, 4]).astype("float64")
@@ -85,7 +79,7 @@ def test_gemm_mma_m8n8k4_row_col_fp64pf64fp64():
     golden = np.matmul(A_np.astype("float64"), B_np.astype("float64").T)
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -150,10 +144,10 @@ def gemm_mma_m8n8k4_row_row_fp16fp16fp16(a: T.handle, b: T.handle, c: T.handle):
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(7), reason="need cuda compute >= 7.0")
 def test_gemm_mma_m8n8k4_row_row_fp16fp16fp16():
     sch = tvm.s_tir.Schedule(gemm_mma_m8n8k4_row_row_fp16fp16fp16)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-1, 1, [16, 4]).astype("float16")
     B_np = np.random.uniform(-1, 1, [4, 16]).astype("float16")
@@ -162,7 +156,7 @@ def test_gemm_mma_m8n8k4_row_row_fp16fp16fp16():
     golden = np.matmul(A_np.astype("float16"), B_np.astype("float16"))
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -234,10 +228,10 @@ def gemm_mma_m8n8k4_row_row_fp16fp16fp32(a: T.handle, b: T.handle, c: T.handle):
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(7), reason="need cuda compute >= 7.0")
 def test_gemm_mma_m8n8k4_row_row_fp16fp16fp32():
     sch = tvm.s_tir.Schedule(gemm_mma_m8n8k4_row_row_fp16fp16fp32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-1, 1, [16, 4]).astype("float16")
     B_np = np.random.uniform(-1, 1, [4, 16]).astype("float16")
@@ -246,7 +240,7 @@ def test_gemm_mma_m8n8k4_row_row_fp16fp16fp32():
     golden = np.matmul(A_np.astype("float32"), B_np.astype("float32"))
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -305,10 +299,11 @@ def gemm_mma_m8n8k16_row_col_s8s8s32(a: T.handle, b: T.handle, c: T.handle):
 # Failure occurs during the external call to nvcc, when attempting to
 # generate the .fatbin file.
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_nvcc_version(11), reason="need nvcc >= 11")
+@pytest.mark.skipif(not env.has_cuda_compute(7, 5), reason="need cuda compute >= 7.5")
 def test_gemm_mma_m8n8k16_row_col_s8s8s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m8n8k16_row_col_s8s8s32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-10, 10, [8, 16]).astype("int8")
     B_np = np.random.uniform(-10, 10, [8, 16]).astype("int8")
@@ -317,7 +312,7 @@ def test_gemm_mma_m8n8k16_row_col_s8s8s32():
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -376,10 +371,11 @@ def gemm_mma_m8n8k16_row_col_s8u8s32(a: T.handle, b: T.handle, c: T.handle):
 # Failure occurs during the external call to nvcc, when attempting to
 # generate the .fatbin file.
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_nvcc_version(11), reason="need nvcc >= 11")
+@pytest.mark.skipif(not env.has_cuda_compute(7, 5), reason="need cuda compute >= 7.5")
 def test_gemm_mma_m8n8k16_row_col_s8u8s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m8n8k16_row_col_s8u8s32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-10, 10, [8, 16]).astype("int8")
     B_np = np.random.uniform(-10, 10, [8, 16]).astype("uint8")
@@ -388,7 +384,7 @@ def test_gemm_mma_m8n8k16_row_col_s8u8s32():
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -447,13 +443,14 @@ def gemm_mma_m8n8k32_row_col_s4s4s32(a: T.handle, b: T.handle, c: T.handle):
 # Failure occurs during the external call to nvcc, when attempting to
 # generate the .fatbin file.
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_nvcc_version(11), reason="need nvcc >= 11")
+@pytest.mark.skipif(not env.has_cuda_compute(7, 5), reason="need cuda compute >= 7.5")
 def test_gemm_mma_m8n8k32_row_col_s4s4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m8n8k32_row_col_s4s4s32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
         B_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
         C_tvm = tvm.runtime.empty([8, 8], "int32", ctx)
@@ -512,13 +509,14 @@ def gemm_mma_m8n8k32_row_col_s4u4s32(a: T.handle, b: T.handle, c: T.handle):
 # Failure occurs during the external call to nvcc, when attempting to
 # generate the .fatbin file.
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_nvcc_version(11), reason="need nvcc >= 11")
+@pytest.mark.skipif(not env.has_cuda_compute(7, 5), reason="need cuda compute >= 7.5")
 def test_gemm_mma_m8n8k32_row_col_s4u4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m8n8k32_row_col_s4u4s32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
         B_tvm = tvm.runtime.empty([8, 32], "uint4", ctx)
         C_tvm = tvm.runtime.empty([8, 8], "int32", ctx)
@@ -580,10 +578,10 @@ def gemm_mma_m16n8k8_row_col_fp16fp16fp32(a: T.handle, b: T.handle, c: T.handle)
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_gemm_mma_m16n8k8_row_col_fp16fp16fp32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k8_row_col_fp16fp16fp32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-1, 1, [16, 8]).astype("float16")
     B_np = np.random.uniform(-1, 1, [8, 8]).astype("float16")
@@ -592,7 +590,7 @@ def test_gemm_mma_m16n8k8_row_col_fp16fp16fp32():
     golden = np.matmul(A_np.astype("float32"), B_np.astype("float32").T)
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -657,10 +655,10 @@ def gemm_mma_m16n8k16_row_col_fp16fp16fp16(a: T.handle, b: T.handle, c: T.handle
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_gemm_mma_m16n8k16_row_col_fp16fp16fp16():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k16_row_col_fp16fp16fp16)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-1, 1, [16, 16]).astype("float16")
     B_np = np.random.uniform(-1, 1, [8, 16]).astype("float16")
@@ -669,7 +667,7 @@ def test_gemm_mma_m16n8k16_row_col_fp16fp16fp16():
     golden = np.matmul(A_np.astype("float16"), B_np.astype("float16").T)
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -734,10 +732,10 @@ def gemm_mma_m16n8k16_row_col_fp16fp16fp32(a: T.handle, b: T.handle, c: T.handle
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_gemm_mma_m16n8k16_row_col_fp16fp16fp32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k16_row_col_fp16fp16fp32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-1, 1, [16, 16]).astype("float16")
     B_np = np.random.uniform(-1, 1, [8, 16]).astype("float16")
@@ -746,7 +744,7 @@ def test_gemm_mma_m16n8k16_row_col_fp16fp16fp32():
     golden = np.matmul(A_np.astype("float32"), B_np.astype("float32").T)
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -811,10 +809,10 @@ def gemm_mma_m16n8k16_row_col_s8s8s32(a: T.handle, b: T.handle, c: T.handle):
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_gemm_mma_m16n8k16_row_col_s8s8s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k16_row_col_s8s8s32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-10, 10, [16, 16]).astype("int8")
     B_np = np.random.uniform(-10, 10, [8, 16]).astype("int8")
@@ -823,7 +821,7 @@ def test_gemm_mma_m16n8k16_row_col_s8s8s32():
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -888,10 +886,10 @@ def gemm_mma_m16n8k16_row_col_s8u8s32(a: T.handle, b: T.handle, c: T.handle):
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_gemm_mma_m16n8k16_row_col_s8u8s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k16_row_col_s8u8s32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-10, 10, [16, 16]).astype("int8")
     B_np = np.random.uniform(-10, 10, [8, 16]).astype("uint8")
@@ -900,7 +898,7 @@ def test_gemm_mma_m16n8k16_row_col_s8u8s32():
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -965,10 +963,10 @@ def gemm_mma_m16n8k32_row_col_s8s8s32(a: T.handle, b: T.handle, c: T.handle):
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_gemm_mma_m16n8k32_row_col_s8s8s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k32_row_col_s8s8s32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-10, 10, [16, 32]).astype("int8")
     B_np = np.random.uniform(-10, 10, [8, 32]).astype("int8")
@@ -977,7 +975,7 @@ def test_gemm_mma_m16n8k32_row_col_s8s8s32():
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -1042,10 +1040,10 @@ def gemm_mma_m16n8k32_row_col_s8u8s32(a: T.handle, b: T.handle, c: T.handle):
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_gemm_mma_m16n8k32_row_col_s8u8s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k32_row_col_s8u8s32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     A_np = np.random.uniform(-10, 10, [16, 32]).astype("int8")
     B_np = np.random.uniform(-10, 10, [8, 32]).astype("uint8")
@@ -1054,7 +1052,7 @@ def test_gemm_mma_m16n8k32_row_col_s8u8s32():
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.tensor(A_np, ctx)
         B_tvm = tvm.runtime.tensor(B_np, ctx)
         C_tvm = tvm.runtime.tensor(C_np, ctx)
@@ -1119,13 +1117,13 @@ def gemm_mma_m16n8k64_row_col_s4s4s32(a: T.handle, b: T.handle, c: T.handle):
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_gemm_mma_m16n8k64_row_col_s4s4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k64_row_col_s4s4s32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.empty([16, 64], "int4", ctx)
         B_tvm = tvm.runtime.empty([8, 64], "int4", ctx)
         C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)
@@ -1190,13 +1188,13 @@ def gemm_mma_m16n8k64_row_col_s4u4s32(a: T.handle, b: T.handle, c: T.handle):
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_gemm_mma_m16n8k64_row_col_s4u4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k64_row_col_s4u4s32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.empty([16, 64], "int4", ctx)
         B_tvm = tvm.runtime.empty([8, 64], "uint4", ctx)
         C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)
@@ -1262,13 +1260,13 @@ def gemm_mma_m16n8k256_row_col_b1b1s32(a: T.handle, b: T.handle, c: T.handle):
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_gemm_mma_m16n8k256_row_col_b1b1s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k256_row_col_b1b1s32)
-    cuda_mod = tvm.compile(sch.mod, target="maca")
+    cuda_mod = tvm.compile(sch.mod, target="cuda")
 
     def run_and_check():
-        ctx = tvm.maca()
+        ctx = tvm.cuda()
         A_tvm = tvm.runtime.empty([16, 256], "int1", ctx)
         B_tvm = tvm.runtime.empty([8, 256], "int1", ctx)
         C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)

--- a/tests/python/tirx-base/test_tir_ptx_mma_sp.py
+++ b/tests/python/tirx-base/test_tir_ptx_mma_sp.py
@@ -23,12 +23,6 @@ import tvm.testing
 from tvm.script import tirx as T
 from tvm.testing import env
 
-MACA_PTX_SPARSE_MMA_XFAIL_REASON = (
-    "TODO(maca): [ptx-sparse-mma] support PTX sparse MMA lowering with metadata operands"
-)
-
-pytestmark = pytest.mark.xfail(reason=MACA_PTX_SPARSE_MMA_XFAIL_REASON, strict=False)
-
 
 def gen_2in4_mask(m: int, n: int):
     assert n % 4 == 0
@@ -255,7 +249,7 @@ def mma_sp_m16n8k32_f16f16f32(a: T.handle, b: T.handle, c: T.handle, _metadata: 
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_mma_sp_m16n8k16_f16():
     def get_meta_m16n8k16_half(mask):
         assert mask.shape == (16, 4, 2)
@@ -273,7 +267,7 @@ def test_mma_sp_m16n8k16_f16():
     for out_dtype in ["float16", "float32"]:
         func = mma_sp_m16n8k16_f16f16f16 if out_dtype == "float16" else mma_sp_m16n8k16_f16f16f32
         sch = tvm.s_tir.Schedule(func)
-        cuda_mod = tvm.compile(sch.mod, target="maca")
+        cuda_mod = tvm.compile(sch.mod, target="cuda")
 
         A_np = np.random.uniform(-1, 1, [16, 8]).astype("float16")
         B_np = np.random.uniform(-1, 1, [16, 8]).astype("float16")
@@ -283,7 +277,7 @@ def test_mma_sp_m16n8k16_f16():
         meta = get_meta_m16n8k16_half(mask)
 
         def run_and_check():
-            ctx = tvm.maca()
+            ctx = tvm.cuda()
             A_tvm = tvm.runtime.tensor(A_np, ctx)
             B_tvm = tvm.runtime.tensor(B_np, ctx)
             C_tvm = tvm.runtime.tensor(np.zeros_like(C_np), ctx)
@@ -295,7 +289,7 @@ def test_mma_sp_m16n8k16_f16():
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
+@pytest.mark.skipif(not env.has_cuda_compute(8), reason="need cuda compute >= 8.0")
 def test_mma_sp_m16n8k32_f16():
     def get_meta_m16n8k32_half(mask):
         assert mask.shape == (16, 8, 2)
@@ -315,7 +309,7 @@ def test_mma_sp_m16n8k32_f16():
     for out_dtype in ["float16", "float32"]:
         func = mma_sp_m16n8k32_f16f16f16 if out_dtype == "float16" else mma_sp_m16n8k32_f16f16f32
         sch = tvm.s_tir.Schedule(func)
-        cuda_mod = tvm.compile(sch.mod, target="maca")
+        cuda_mod = tvm.compile(sch.mod, target="cuda")
 
         A_np = np.random.uniform(-1, 1, [16, 16]).astype("float16")
         B_np = np.random.uniform(-1, 1, [32, 8]).astype("float16")
@@ -325,7 +319,7 @@ def test_mma_sp_m16n8k32_f16():
         meta = get_meta_m16n8k32_half(mask)
 
         def run_and_check():
-            ctx = tvm.maca()
+            ctx = tvm.cuda()
             A_tvm = tvm.runtime.tensor(A_np, ctx)
             B_tvm = tvm.runtime.tensor(B_np, ctx)
             C_tvm = tvm.runtime.tensor(np.zeros_like(C_np), ctx)

--- a/tests/python/tirx-base/test_tir_ptx_scalar_f32_math.py
+++ b/tests/python/tirx-base/test_tir_ptx_scalar_f32_math.py
@@ -23,11 +23,6 @@ import tvm.testing
 from tvm.script import tirx as T
 from tvm.testing import env
 
-MACA_PTX_SCALAR_F32_XFAIL_REASON = (
-    "TODO(maca): [ptx-f32-math] support PTX scalar f32 math intrinsics such as add, "
-    "multiply, and maximum"
-)
-
 
 @T.prim_func(s_tir=True)
 def ptx_scalar_f32_math(
@@ -51,18 +46,17 @@ def ptx_scalar_f32_math(
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_maca(), reason="need maca")
-@pytest.mark.xfail(reason=MACA_PTX_SCALAR_F32_XFAIL_REASON, strict=False)
+@pytest.mark.skipif(not env.has_cuda_compute(7), reason="need cuda compute >= 7.0")
 def test_ptx_scalar_f32_math():
     f = ptx_scalar_f32_math
-    mod = tvm.compile(f, target="maca")
+    mod = tvm.compile(f, target="cuda")
     rng = np.random.default_rng(0)
     A_np = rng.standard_normal(32).astype("float32")
     B_np = rng.standard_normal(32).astype("float32")
     Z = np.zeros((32,), dtype="float32")
 
     def run_and_check():
-        dev = tvm.maca(0)
+        dev = tvm.cuda(0)
         A_nd = tvm.runtime.tensor(A_np, device=dev)
         B_nd = tvm.runtime.tensor(B_np, device=dev)
         Cadd = tvm.runtime.tensor(Z.copy(), device=dev)


### PR DESCRIPTION
## Motivation

This PR reverts several PTX-specific TensorIR (TIR) test cases back to their upstream `main` state. 

Currently, these tests heavily rely on NVIDIA-specific hardware behaviors, particularly the 32-thread warp size and specific register layouts (e.g., software fallbacks for `ldmatrix` with hardcoded 32-thread indexing). When running on architectures with a 64-thread warp/wavefront (such as Moore Threads MACA), these hardcoded memory mapping formulas cause severe data layout misalignment and precision issues. 

Instead of adding complex, architecture-specific `if/else` fallbacks that pollute the PTX test suite, we are rolling these files back to cleanly align with upstream.

## Modifications
Reverted the following files to the latest `upstream/main` state via `git checkout`:
* `tests/python/tirx-base/test_tir_ptx_cp_async.py`
* `tests/python/tirx-base/test_tir_ptx_griddepcontrol.py`
* `tests/python/tirx-base/test_tir_ptx_ldmatrix.py`
* `tests/python/tirx-base/test_tir_ptx_mma.py`
* `tests/python/tirx-base/test_tir_ptx_mma_sp.py`
* `tests/python/tirx-base/test_tir_ptx_scalar_f32_math.py`

## Target Branch
`dev`