### PR TITLE
[TIRx][MACA] Support scope reduction

### DIFF
--- a/python/tvm/backend/maca/intrinsics/__init__.py
+++ b/python/tvm/backend/maca/intrinsics/__init__.py
@@ -22,7 +22,7 @@
 """
 
 # Import op modules to register their codegen functions.
-from . import memory, sync
+from . import math, memory, sync
 from .registry import CODEGEN_REGISTRY, get_codegen, register_codegen
 
 __all__ = [

--- a/python/tvm/backend/maca/intrinsics/math.py
+++ b/python/tvm/backend/maca/intrinsics/math.py
@@ -1,0 +1,131 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""MACA math helpers, including Wave64 reductions."""
+
+from __future__ import annotations
+
+from tvm.backend.maca.op import maca_func_call
+
+from .registry import register_codegen
+from .utils import parse_str, validate_power_of_two_range
+
+_WAVE_SIZE = 64
+_FULL_WAVE_MASK = "0xFFFFFFFFFFFFFFFFULL"
+_REDUCE_STEPS = {
+    "sum": "val += shuffled;",
+    "max": "val = (val > shuffled) ? val : shuffled;",
+    "min": "val = (val < shuffled) ? val : shuffled;",
+}
+
+
+def _reduce_step(op, context: str) -> tuple[str, str]:
+    """Return the normalized reduction name and device-side combine step."""
+    op_name = parse_str(op)
+    try:
+        return op_name, _REDUCE_STEPS[op_name]
+    except KeyError as error:
+        expected = ", ".join(sorted(_REDUCE_STEPS))
+        raise ValueError(
+            f"Unsupported {context} op {op_name!r}; expected one of {expected}"
+        ) from error
+
+
+def _validate_wave_width(width) -> int:
+    """Validate a subgroup width within one Wave64."""
+    return validate_power_of_two_range(width, 2, _WAVE_SIZE, "maca warp_reduce width")
+
+
+def _validate_cta_waves(num_waves) -> int:
+    """Validate the supported power-of-two number of waves in a CTA."""
+    return validate_power_of_two_range(num_waves, 1, 16, "maca cta_reduce num_waves")
+
+
+def _warp_reduce_source(func_name: str, width: int, combine_step: str) -> str:
+    """Emit a full-mask XOR butterfly reduction helper for a Wave64 subgroup."""
+    return (
+        "\n"
+        "template <typename T>\n"
+        f"__forceinline__ __device__ T {func_name}(T val) {{\n"
+        "    #pragma unroll\n"
+        f"    for (int xor_mask = {width} >> 1; xor_mask > 0; xor_mask >>= 1) {{\n"
+        f"        T shuffled = __shfl_xor_sync({_FULL_WAVE_MASK}, val, xor_mask, {width});\n"
+        f"        {combine_step}\n"
+        "    }\n"
+        "    return val;\n"
+        "}\n"
+    )
+
+
+@register_codegen("maca_warp_reduce")
+def codegen_maca_warp_reduce(value, op, width):
+    """Lower a scalar all-reduce over a power-of-two Wave64 subgroup."""
+    op_name, combine_step = _reduce_step(op, "maca warp_reduce")
+    width_int = _validate_wave_width(width)
+    func_name = f"tvm_builtin_maca_warp_reduce_{op_name}_{width_int}"
+    return maca_func_call(
+        func_name,
+        value,
+        source_code=_warp_reduce_source(func_name, width_int, combine_step),
+        return_type=value.ty,
+    )
+
+
+@register_codegen("maca_cta_reduce")
+def codegen_maca_cta_reduce(value, op, num_waves, scratch):
+    """Lower a CTA all-reduce over one to sixteen Wave64 groups."""
+    op_name, combine_step = _reduce_step(op, "maca cta_reduce")
+    waves = _validate_cta_waves(num_waves)
+
+    wave_reduce_name = f"tvm_builtin_maca_warp_reduce_{op_name}_{_WAVE_SIZE}"
+    cta_reduce_name = f"tvm_builtin_maca_cta_reduce_{op_name}_{waves}"
+    source_code = _warp_reduce_source(wave_reduce_name, _WAVE_SIZE, combine_step)
+
+    # The second stage reduces one value per wave.  Restricting wave counts to
+    # powers of two avoids injecting a type-specific identity into inactive lanes.
+    partial_reduce_name = f"tvm_builtin_maca_warp_reduce_{op_name}_{waves}"
+    if waves > 1:
+        source_code += _warp_reduce_source(partial_reduce_name, waves, combine_step)
+
+    source_code += (
+        "template <typename T>\n"
+        f"__forceinline__ __device__ T {cta_reduce_name}(T val, void* scratch_raw) {{\n"
+        "    T* scratch = reinterpret_cast<T*>(scratch_raw);\n"
+        "    int tid = threadIdx.x + threadIdx.y * blockDim.x"
+        " + threadIdx.z * blockDim.x * blockDim.y;\n"
+        f"    int wave_id = tid / {_WAVE_SIZE};\n"
+        f"    int lane_id = tid % {_WAVE_SIZE};\n"
+        f"    val = {wave_reduce_name}(val);\n"
+        "    if (lane_id == 0) scratch[wave_id] = val;\n"
+        "    __syncthreads();\n"
+        "    if (wave_id == 0) {\n"
+        f"        T partial = lane_id < {waves} ? scratch[lane_id] : val;\n"
+    )
+    if waves > 1:
+        source_code += f"        partial = {partial_reduce_name}(partial);\n"
+    source_code += (
+        "        if (lane_id == 0) scratch[0] = partial;\n"
+        "    }\n"
+        "    __syncthreads();\n"
+        "    return scratch[0];\n"
+        "}\n"
+    )
+    return maca_func_call(
+        cta_reduce_name, value, scratch, source_code=source_code, return_type=value.ty
+    )
+
+
+__all__ = ["codegen_maca_cta_reduce", "codegen_maca_warp_reduce"]

--- a/python/tvm/backend/maca/op.py
+++ b/python/tvm/backend/maca/op.py
@@ -49,6 +49,50 @@ def maca_func_call(func_name, *args, source_code, return_type="void"):
     return call_intrin(return_type, "tirx.maca.func_call", func_name, *args, source_code)
 
 
+def maca_warp_reduce(value, op, width=64):
+    """Reduce a scalar over a MACA Wave64 power-of-two subgroup.
+
+    ``width`` must be a power of two in ``[2, 64]``. The code generator
+    validates this constraint and emits a full-Wave64-mask XOR butterfly.
+    """
+    return call_intrin(value.ty, "tirx.maca.warp_reduce", value, op, width)
+
+
+def maca_warp_sum(value, width=64):
+    """Reduce a scalar sum over a MACA Wave64 subgroup."""
+    return maca_warp_reduce(value, "sum", width)
+
+
+def maca_warp_max(value, width=64):
+    """Reduce a scalar maximum over a MACA Wave64 subgroup."""
+    return maca_warp_reduce(value, "max", width)
+
+
+def maca_warp_min(value, width=64):
+    """Reduce a scalar minimum over a MACA Wave64 subgroup."""
+    return maca_warp_reduce(value, "min", width)
+
+
+def maca_cta_reduce(value, op, num_waves, scratch):
+    """Reduce a scalar over a CTA of one to sixteen MACA Wave64 groups."""
+    return call_intrin(value.ty, "tirx.maca.cta_reduce", value, op, num_waves, scratch)
+
+
+def maca_cta_sum(value, num_waves, scratch):
+    """Reduce a scalar sum over MACA waves in a CTA."""
+    return maca_cta_reduce(value, "sum", num_waves, scratch)
+
+
+def maca_cta_max(value, num_waves, scratch):
+    """Reduce a scalar maximum over MACA waves in a CTA."""
+    return maca_cta_reduce(value, "max", num_waves, scratch)
+
+
+def maca_cta_min(value, num_waves, scratch):
+    """Reduce a scalar minimum over MACA waves in a CTA."""
+    return maca_cta_reduce(value, "min", num_waves, scratch)
+
+
 def maca_thread_fence():
     """TVM intrinsic to call maca thread fence instruction
 

--- a/python/tvm/backend/maca/script.py
+++ b/python/tvm/backend/maca/script.py
@@ -31,6 +31,14 @@ class MACANamespace:
 
     def __init__(self):
         self.func_call = _op_wrapper(_maca_op.maca_func_call)
+        self.warp_reduce = _op_wrapper(_maca_op.maca_warp_reduce)
+        self.warp_sum = _op_wrapper(_maca_op.maca_warp_sum)
+        self.warp_max = _op_wrapper(_maca_op.maca_warp_max)
+        self.warp_min = _op_wrapper(_maca_op.maca_warp_min)
+        self.cta_reduce = _op_wrapper(_maca_op.maca_cta_reduce)
+        self.cta_sum = _op_wrapper(_maca_op.maca_cta_sum)
+        self.cta_max = _op_wrapper(_maca_op.maca_cta_max)
+        self.cta_min = _op_wrapper(_maca_op.maca_cta_min)
         self.thread_fence = _op_wrapper(_maca_op.maca_thread_fence)
         self.warp_sync = _op_wrapper(_maca_op.maca_warp_sync)
         self.cta_sync = _op_wrapper(_maca_op.maca_cta_sync)

--- a/src/backend/maca/op/target_builtin.cc
+++ b/src/backend/maca/op/target_builtin.cc
@@ -95,6 +95,8 @@ void RegisterDeviceIntrinsic(const DeviceIntrinsicRegistration& reg) {
 
 const DeviceIntrinsicRegistration kDeviceIntrinsics[] = {
     TIRX_DEVICE_INTRIN_ALIAS(maca_func_call, maca, kOpaque),
+    TIRX_DEVICE_INTRIN_ALIAS(maca_warp_reduce, maca, kOpaque),
+    TIRX_DEVICE_INTRIN_ALIAS(maca_cta_reduce, maca, kOpaque),
     TIRX_DEVICE_INTRIN_ALIAS(maca_thread_fence, maca, kOpaque),
     TIRX_DEVICE_INTRIN_ALIAS(maca_warp_sync, maca, kOpaque),
     TIRX_DEVICE_INTRIN_ALIAS(maca_cta_sync, maca, kOpaque),

--- a/tests/python/tirx/codegen/test_cuda_cta_reduce.py
+++ b/tests/python/tirx/codegen/test_cuda_cta_reduce.py
@@ -23,12 +23,6 @@ import tvm
 from tvm.script import tirx as T
 from tvm.testing import env
 
-MACA_TIRX_CTA_REDUCE_XFAIL_REASON = (
-    "TODO(maca): [cta-reduce] support TIRX CTA reduction helpers and shared scratch lowering"
-)
-
-pytestmark = pytest.mark.xfail(reason=MACA_TIRX_CTA_REDUCE_XFAIL_REASON, strict=False)
-
 TARGET = tvm.target.Target("maca")
 
 
@@ -50,8 +44,8 @@ def _build_and_run(func, n):
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
 def test_cta_sum_4_warps():
     """CTA sum with 4 warps (128 threads): all threads get the same sum."""
-    NUM_WARPS = 4
-    N = NUM_WARPS * 32
+    NUM_WAVES = 4
+    N = NUM_WAVES * 64
 
     # fmt: off
     @T.prim_func
@@ -59,27 +53,27 @@ def test_cta_sum_4_warps():
         out = T.match_buffer(out_ptr, (N,), "float32")
         T.device_entry()
         cta_id = T.cta_id([1])
-        warp_id = T.warp_id([NUM_WARPS])
-        lane_id = T.lane_id([32])
+        warp_id = T.warp_id([NUM_WAVES])
+        lane_id = T.lane_id([64])
         tid = T.thread_id([N])
-        scratch = T.alloc_buffer((NUM_WARPS,), "float32", scope="shared")
+        scratch = T.alloc_buffer((NUM_WAVES,), "float32", scope="shared")
         val: T.f32 = T.float32(tid + 1)
-        val = T.cuda.cta_sum(val, NUM_WARPS, scratch.ptr_to([0]))
+        val = T.maca.cta_sum(val, NUM_WAVES, scratch.ptr_to([0]))
         out[tid] = val
         # fmt: on
 
     result, mod = _build_and_run(func, N)
     expected = np.float32(N * (N + 1) / 2)  # sum(1..128)
     np.testing.assert_allclose(result, np.full(N, expected))
-    assert "cta_reduce_sum_4" in mod.mod.imports[0].inspect_source()
+    assert "maca_cta_reduce_sum_4" in mod.mod.imports[0].inspect_source()
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
 def test_cta_sum_8_warps():
     """CTA sum with 8 warps (256 threads)."""
-    NUM_WARPS = 8
-    N = NUM_WARPS * 32
+    NUM_WAVES = 8
+    N = NUM_WAVES * 64
 
     # fmt: off
     @T.prim_func
@@ -87,12 +81,12 @@ def test_cta_sum_8_warps():
         out = T.match_buffer(out_ptr, (N,), "float32")
         T.device_entry()
         cta_id = T.cta_id([1])
-        warp_id = T.warp_id([NUM_WARPS])
-        lane_id = T.lane_id([32])
+        warp_id = T.warp_id([NUM_WAVES])
+        lane_id = T.lane_id([64])
         tid = T.thread_id([N])
-        scratch = T.alloc_buffer((NUM_WARPS,), "float32", scope="shared")
+        scratch = T.alloc_buffer((NUM_WAVES,), "float32", scope="shared")
         val: T.f32 = T.float32(tid + 1)
-        val = T.cuda.cta_sum(val, NUM_WARPS, scratch.ptr_to([0]))
+        val = T.maca.cta_sum(val, NUM_WAVES, scratch.ptr_to([0]))
         out[tid] = val
         # fmt: on
 
@@ -105,8 +99,8 @@ def test_cta_sum_8_warps():
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
 def test_cta_max_4_warps():
     """CTA max with 4 warps: all threads get the maximum value."""
-    NUM_WARPS = 4
-    N = NUM_WARPS * 32
+    NUM_WAVES = 4
+    N = NUM_WAVES * 64
 
     # fmt: off
     @T.prim_func
@@ -114,12 +108,12 @@ def test_cta_max_4_warps():
         out = T.match_buffer(out_ptr, (N,), "float32")
         T.device_entry()
         cta_id = T.cta_id([1])
-        warp_id = T.warp_id([NUM_WARPS])
-        lane_id = T.lane_id([32])
+        warp_id = T.warp_id([NUM_WAVES])
+        lane_id = T.lane_id([64])
         tid = T.thread_id([N])
-        scratch = T.alloc_buffer((NUM_WARPS,), "float32", scope="shared")
+        scratch = T.alloc_buffer((NUM_WAVES,), "float32", scope="shared")
         val: T.f32 = T.float32(tid + 1)
-        val = T.cuda.cta_max(val, NUM_WARPS, scratch.ptr_to([0]))
+        val = T.maca.cta_max(val, NUM_WAVES, scratch.ptr_to([0]))
         out[tid] = val
         # fmt: on
 
@@ -131,8 +125,8 @@ def test_cta_max_4_warps():
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
 def test_cta_min_4_warps():
     """CTA min with 4 warps: all threads get the minimum value."""
-    NUM_WARPS = 4
-    N = NUM_WARPS * 32
+    NUM_WAVES = 4
+    N = NUM_WAVES * 64
 
     # fmt: off
     @T.prim_func
@@ -140,12 +134,12 @@ def test_cta_min_4_warps():
         out = T.match_buffer(out_ptr, (N,), "float32")
         T.device_entry()
         cta_id = T.cta_id([1])
-        warp_id = T.warp_id([NUM_WARPS])
-        lane_id = T.lane_id([32])
+        warp_id = T.warp_id([NUM_WAVES])
+        lane_id = T.lane_id([64])
         tid = T.thread_id([N])
-        scratch = T.alloc_buffer((NUM_WARPS,), "float32", scope="shared")
+        scratch = T.alloc_buffer((NUM_WAVES,), "float32", scope="shared")
         val: T.f32 = T.float32(tid + 1)
-        val = T.cuda.cta_min(val, NUM_WARPS, scratch.ptr_to([0]))
+        val = T.maca.cta_min(val, NUM_WAVES, scratch.ptr_to([0]))
         out[tid] = val
         # fmt: on
 
@@ -157,8 +151,8 @@ def test_cta_min_4_warps():
 @pytest.mark.skipif(not env.has_maca(), reason="need maca")
 def test_cta_sum_1_warp():
     """CTA sum with 1 warp: degenerates to a pure warp reduce."""
-    NUM_WARPS = 1
-    N = 32
+    NUM_WAVES = 1
+    N = 64
 
     # fmt: off
     @T.prim_func
@@ -166,17 +160,17 @@ def test_cta_sum_1_warp():
         out = T.match_buffer(out_ptr, (N,), "float32")
         T.device_entry()
         cta_id = T.cta_id([1])
-        warp_id = T.warp_id([NUM_WARPS])
-        lane_id = T.lane_id([32])
+        warp_id = T.warp_id([NUM_WAVES])
+        lane_id = T.lane_id([64])
         tid = T.thread_id([N])
-        scratch = T.alloc_buffer((NUM_WARPS,), "float32", scope="shared")
+        scratch = T.alloc_buffer((NUM_WAVES,), "float32", scope="shared")
         val: T.f32 = T.float32(tid + 1)
-        val = T.cuda.cta_sum(val, NUM_WARPS, scratch.ptr_to([0]))
+        val = T.maca.cta_sum(val, NUM_WAVES, scratch.ptr_to([0]))
         out[tid] = val
         # fmt: on
 
     result, _ = _build_and_run(func, N)
-    expected = np.float32(32 * 33 / 2)
+    expected = np.float32(64 * 65 / 2)
     np.testing.assert_allclose(result, np.full(N, expected))
 
 
@@ -185,7 +179,7 @@ def test_cta_sum_1_warp():
 @pytest.mark.parametrize("num_warps", [1, 2, 4, 8, 16])
 def test_cta_sum_all_warp_counts(num_warps):
     """Parametric test: cta_sum with various warp counts."""
-    N = num_warps * 32
+    N = num_warps * 64
 
     # fmt: off
     @T.prim_func
@@ -194,11 +188,11 @@ def test_cta_sum_all_warp_counts(num_warps):
         T.device_entry()
         cta_id = T.cta_id([1])
         warp_id = T.warp_id([num_warps])
-        lane_id = T.lane_id([32])
+        lane_id = T.lane_id([64])
         tid = T.thread_id([N])
         scratch = T.alloc_buffer((num_warps,), "float32", scope="shared")
         val: T.f32 = T.float32(tid + 1)
-        val = T.cuda.cta_sum(val, num_warps, scratch.ptr_to([0]))
+        val = T.maca.cta_sum(val, num_warps, scratch.ptr_to([0]))
         out[tid] = val
         # fmt: on
 

--- a/tests/python/tirx/codegen/test_cuda_warp_reduce.py
+++ b/tests/python/tirx/codegen/test_cuda_warp_reduce.py
@@ -23,16 +23,10 @@ import tvm
 from tvm.script import tirx as T
 from tvm.testing import env
 
-MACA_TIRX_WARP_REDUCE_XFAIL_REASON = (
-    "TODO(maca): [warp-reduce] support TIRX warp reduction helpers and lane-scope lowering"
-)
-
-pytestmark = pytest.mark.xfail(reason=MACA_TIRX_WARP_REDUCE_XFAIL_REASON, strict=False)
-
 TARGET = tvm.target.Target("maca")
 
 
-def _build_and_run(func, n=32):
+def _build_and_run(func, n=64):
     mod = tvm.IRModule({"main": func})
     mod = tvm.compile(mod, target=TARGET, tir_pipeline="tirx")
     out_np = np.zeros(n, dtype="float32")
@@ -54,20 +48,20 @@ def test_warp_sum_full():
     # fmt: off
     @T.prim_func
     def func(out_ptr: T.handle):
-        out = T.match_buffer(out_ptr, (32,), "float32")
+        out = T.match_buffer(out_ptr, (64,), "float32")
         T.device_entry()
         cta_id = T.cta_id([1])
         warp_id = T.warp_id([1])
-        lane = T.lane_id([32])
+        lane = T.lane_id([64])
         val: T.f32 = T.float32(lane + 1)
-        val = T.cuda.warp_sum(val)
+        val = T.maca.warp_sum(val)
         out[lane] = val
         # fmt: on
 
     result, mod = _build_and_run(func)
-    expected = np.float32(32 * 33 / 2)  # sum(1..32)
-    np.testing.assert_allclose(result, np.full(32, expected))
-    assert "warp_reduce_sum_32" in mod.mod.imports[0].inspect_source()
+    expected = np.float32(64 * 65 / 2)  # sum(1..32)
+    np.testing.assert_allclose(result, np.full(64, expected))
+    assert "maca_warp_reduce_sum_64" in mod.mod.imports[0].inspect_source()
 
 
 @pytest.mark.gpu
@@ -78,13 +72,13 @@ def test_warp_sum_partial_8():
     # fmt: off
     @T.prim_func
     def func(out_ptr: T.handle):
-        out = T.match_buffer(out_ptr, (32,), "float32")
+        out = T.match_buffer(out_ptr, (64,), "float32")
         T.device_entry()
         cta_id = T.cta_id([1])
         warp_id = T.warp_id([1])
-        lane = T.lane_id([32])
+        lane = T.lane_id([64])
         val: T.f32 = T.float32(lane + 1)
-        val = T.cuda.warp_sum(val, width=8)
+        val = T.maca.warp_sum(val, width=8)
         out[lane] = val
         # fmt: on
 
@@ -93,8 +87,8 @@ def test_warp_sum_partial_8():
     # Group 1: lanes 8-15 → sum(9..16) = 100
     # Group 2: lanes 16-23 → sum(17..24) = 164
     # Group 3: lanes 24-31 → sum(25..32) = 228
-    expected = np.zeros(32, dtype="float32")
-    for g in range(4):
+    expected = np.zeros(64, dtype="float32")
+    for g in range(8):
         group_sum = sum(range(g * 8 + 1, g * 8 + 9))
         expected[g * 8 : (g + 1) * 8] = group_sum
     np.testing.assert_allclose(result, expected)
@@ -108,19 +102,19 @@ def test_warp_max_partial_4():
     # fmt: off
     @T.prim_func
     def func(out_ptr: T.handle):
-        out = T.match_buffer(out_ptr, (32,), "float32")
+        out = T.match_buffer(out_ptr, (64,), "float32")
         T.device_entry()
         cta_id = T.cta_id([1])
         warp_id = T.warp_id([1])
-        lane = T.lane_id([32])
+        lane = T.lane_id([64])
         val: T.f32 = T.float32(lane + 1)
-        val = T.cuda.warp_max(val, width=4)
+        val = T.maca.warp_max(val, width=4)
         out[lane] = val
         # fmt: on
 
     result, _ = _build_and_run(func)
-    expected = np.zeros(32, dtype="float32")
-    for g in range(8):
+    expected = np.zeros(64, dtype="float32")
+    for g in range(16):
         group_max = float(g * 4 + 4)
         expected[g * 4 : (g + 1) * 4] = group_max
     np.testing.assert_allclose(result, expected)
@@ -134,18 +128,18 @@ def test_warp_min_full():
     # fmt: off
     @T.prim_func
     def func(out_ptr: T.handle):
-        out = T.match_buffer(out_ptr, (32,), "float32")
+        out = T.match_buffer(out_ptr, (64,), "float32")
         T.device_entry()
         cta_id = T.cta_id([1])
         warp_id = T.warp_id([1])
-        lane = T.lane_id([32])
+        lane = T.lane_id([64])
         val: T.f32 = T.float32(lane + 1)
-        val = T.cuda.warp_min(val)
+        val = T.maca.warp_min(val)
         out[lane] = val
         # fmt: on
 
     result, _ = _build_and_run(func)
-    np.testing.assert_allclose(result, np.full(32, 1.0))
+    np.testing.assert_allclose(result, np.full(64, 1.0))
 
 
 @pytest.mark.gpu
@@ -156,20 +150,20 @@ def test_warp_sum_partial_2():
     # fmt: off
     @T.prim_func
     def func(out_ptr: T.handle):
-        out = T.match_buffer(out_ptr, (32,), "float32")
+        out = T.match_buffer(out_ptr, (64,), "float32")
         T.device_entry()
         cta_id = T.cta_id([1])
         warp_id = T.warp_id([1])
-        lane = T.lane_id([32])
+        lane = T.lane_id([64])
         val: T.f32 = T.float32(lane)
-        val = T.cuda.warp_sum(val, width=2)
+        val = T.maca.warp_sum(val, width=2)
         out[lane] = val
         # fmt: on
 
     result, _ = _build_and_run(func)
     # Pairs: (0,1)→1, (2,3)→5, (4,5)→9, ...
-    expected = np.zeros(32, dtype="float32")
-    for i in range(16):
+    expected = np.zeros(64, dtype="float32")
+    for i in range(32):
         pair_sum = float(2 * i + 2 * i + 1)
         expected[2 * i] = pair_sum
         expected[2 * i + 1] = pair_sum
@@ -185,19 +179,19 @@ def test_warp_sum_all_widths(width):
     # fmt: off
     @T.prim_func
     def func(out_ptr: T.handle):
-        out = T.match_buffer(out_ptr, (32,), "float32")
+        out = T.match_buffer(out_ptr, (64,), "float32")
         T.device_entry()
         cta_id = T.cta_id([1])
         warp_id = T.warp_id([1])
-        lane = T.lane_id([32])
+        lane = T.lane_id([64])
         val: T.f32 = T.float32(lane)
-        val = T.cuda.warp_sum(val, width=width)
+        val = T.maca.warp_sum(val, width=width)
         out[lane] = val
         # fmt: on
 
     result, _ = _build_and_run(func)
-    expected = np.zeros(32, dtype="float32")
-    num_groups = 32 // width
+    expected = np.zeros(64, dtype="float32")
+    num_groups = 64 // width
     for g in range(num_groups):
         group_sum = sum(range(g * width, (g + 1) * width))
         expected[g * width : (g + 1) * width] = float(group_sum)


### PR DESCRIPTION
Implement MACA warp- and CTA-scope reductions for sum, max, and min
operations. Generate Wave64 shuffle-based reduction helpers, expose the
intrinsics through the T.maca namespace, and register them with the MACA
target.

Update TIRx reduction coverage for MACA.
